### PR TITLE
Avoid deprecation warnings in compiler-rt

### DIFF
--- a/third_party/llvm-project/20.x/compiler-rt/BUILD.tpl
+++ b/third_party/llvm-project/20.x/compiler-rt/BUILD.tpl
@@ -346,6 +346,11 @@ cc_stage2_library(
             "-fomit-frame-pointer",
         ],
         "//conditions:default": [],
+    }) + select({
+        "@platforms//os:macos": [
+            "-Wno-deprecated-declarations",
+         ],
+        "//conditions:default": [],
     }),
     local_defines = selects.with_or({
         (


### PR DESCRIPTION
```
external/toolchains_llvm_bootstrapped++_repo_rules+compiler-rt/lib/builtins/atomic.c:97:9: warning: 'OSSpinLock' is deprecated: first deprecated in macOS 10.12 - Use os_unfair_lock() from <os/lock.h> instead [-Wdeprecated-declarations]
   97 | typedef OSSpinLock Lock;
      |         ^
external/toolchains_llvm_bootstrapped++_repo_rules+macosx15.4.sdk/usr/include/libkern/OSSpinLockDeprecated.h:79:17: note: 'OSSpinLock' has been explicitly marked deprecated here
   79 | typedef int32_t OSSpinLock OSSPINLOCK_DEPRECATED_REPLACE_WITH(os_unfair_lock);
```