### PR TITLE
Add SystemConfiguration framework to the minimal macOS sysroot

### DIFF
--- a/third_party/macosx.sdk/BUILD.MacOSX15.4.sdk.tpl
+++ b/third_party/macosx.sdk/BUILD.MacOSX15.4.sdk.tpl
@@ -58,6 +58,7 @@ directory(
         "System/Library/Frameworks/Kernel.framework/**",
         "System/Library/Frameworks/OSLog.framework/**",
         "System/Library/Frameworks/Security.framework/**",
+        "System/Library/Frameworks/SystemConfiguration.framework/**",
 
         "usr/**",
     ], exclude = COMMON_EXCLUDES),


### PR DESCRIPTION
This seems needed more than I thought.