### PR TITLE
Provide static_runtime_lib/dynamic_runtime_lib to toolchain

### DIFF
--- a/examples/rules_cc/BUILD.bazel
+++ b/examples/rules_cc/BUILD.bazel
@@ -5,6 +5,14 @@ load("//:defs.bzl", "ubsan_cc_binary")
 cc_binary(
     name = "main",
     srcs = ["main.cc"],
+    # We provide these libs explicitly via the toolchain runtime_library.
+    # These options are all no-ops as they resolve to empty stubs.
+    # This is basically a test that we can properly ignore these opts.
+    linkopts = [
+        "-lc++",
+        "-lc++abi",
+        "-lunwind",
+    ],
 )
 
 # TODO(zbarsky): Turn more of this into a macro once we have more sanitizers?

--- a/runtimes/BUILD.bazel
+++ b/runtimes/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//toolchain:selects.bzl", "platform_llvm_binary")
+
+alias(
+    name = "llvm_ar",
+    actual = platform_llvm_binary("bin/llvm-ar"),
+    visibility = ["//runtimes:__subpackages__"],
+)
+
+filegroup(
+    name = "static_runtime_lib",
+    srcs = [
+        "@libcxx//:libcxx.static",
+        "@libcxxabi//:libcxxabi.static",
+        # only if libcxx on linux
+        "@libunwind//:libunwind.static",
+    ],
+    visibility = ["//toolchain:__subpackages__"],
+)
+
+filegroup(
+    name = "dynamic_runtime_lib",
+    srcs = [
+        "@libcxx//:libcxx.shared",
+        "@libcxxabi//:libcxxabi.shared",
+        # only if libcxx on linux
+        # TODO(zbarsky): Enable this? libunwind depends on a another shared lib which loses GraphNodeInfo provider
+        #"@libunwind//:libunwind.shared",
+    ],
+    visibility = ["//toolchain:__subpackages__"],
+)

--- a/runtimes/defs.bzl
+++ b/runtimes/defs.bzl
@@ -1,0 +1,12 @@
+load("@bazel_lib//lib:run_binary.bzl", "run_binary")
+
+def stub_library(name, out = None, visibility = None):
+    out = out or "lib%s.a" % name
+    run_binary(
+        name = name,
+        outs = [out],
+        tool = "//runtimes:llvm_ar",
+        args = ["rc", "$@"],
+        visibility = visibility,
+    )
+

--- a/runtimes/libcxx/BUILD.bazel
+++ b/runtimes/libcxx/BUILD.bazel
@@ -1,23 +1,20 @@
 load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("//runtimes:defs.bzl", "stub_library")
 
-copy_file(
-    name = "libc++",
-    src = "@libcxx//:libcxx.static",
-    out = "libc++.a",
+stub_library(
+    name = "c++",
 )
 
-copy_file(
-    name = "libc++abi",
-    src = "@libcxxabi//:libcxxabi.static",
-    out = "libc++abi.a",
+stub_library(
+    name = "c++abi",
 )
 
 copy_to_directory(
     name = "libcxx_library_search_directory",
     srcs = [
-        ":libc++",
-        ":libc++abi",
+        ":c++",
+        ":c++abi",
     ],
     visibility = ["//visibility:public"],
 )

--- a/runtimes/libunwind/BUILD.bazel
+++ b/runtimes/libunwind/BUILD.bazel
@@ -1,29 +1,15 @@
-load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("//toolchain:selects.bzl", "platform_llvm_binary")
+load("//runtimes:defs.bzl", "stub_library")
 
-copy_file(
-    name = "libunwind",
-    src = "@libunwind//:libunwind.static",
-    out = "libunwind.a",
-    allow_symlink = True,
+stub_library(
+    name = "unwind",
+    visibility = ["//visibility:public"],
 )
 
-alias(
-    name = "llvm_ar",
-    actual = platform_llvm_binary("bin/llvm-ar"),
+stub_library(
+    name = "gcc_s",
+    visibility = ["//visibility:public"],
 )
-
-[
-    genrule(
-        name = lib,
-        srcs = [],
-        outs = ["lib{}.a".format(lib)],
-        tools = [":llvm_ar"],
-        cmd = "$(location :llvm_ar) rc $@",
-        visibility = ["//visibility:public"],
-    ) for lib in ["gcc_s"]
-]
 
 config_setting(
     name = "stub_libgcc_s",
@@ -35,11 +21,9 @@ config_setting(
 copy_to_directory(
     name = "libunwind_library_search_directory",
     srcs = [
-        "libunwind.a",
+        ":unwind",
     ] + select({
-        ":stub_libgcc_s": [
-            "libgcc_s.a",
-        ],
+        ":stub_libgcc_s": [":gcc_s"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],

--- a/runtimes/musl/BUILD.bazel
+++ b/runtimes/musl/BUILD.bazel
@@ -2,7 +2,7 @@ load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@toolchains_llvm_bootstrapped//toolchain/stage2:cc_stage2_library.bzl", "cc_stage2_library")
 load("@toolchains_llvm_bootstrapped//toolchain/stage2:cc_stage2_static_library.bzl", "cc_stage2_static_library")
-load("//toolchain:selects.bzl", "platform_llvm_binary")
+load("//runtimes:defs.bzl", "stub_library")
 load(":libc_musl_srcs_filegroup.bzl", "libc_musl_srcs_filegroup")
 
 libc_musl_srcs_filegroup(
@@ -147,20 +147,12 @@ MUSL_LIBS = [
     "xnet",
 ]
 
-alias(
-    name = "llvm_ar",
-    actual = platform_llvm_binary("bin/llvm-ar"),
-)
-
 # Generate empty static libraries for all other companion libraries.
 # That's what musl does.
 [
-    genrule(
+    stub_library(
         name = "musl_lib{}".format(lib),
-        srcs = [],
-        outs = ["lib{}.a".format(lib)],
-        tools = [":llvm_ar"],
-        cmd = "$(location :llvm_ar) rc $@",
+        out = "lib{}.a".format(lib),
         visibility = ["//visibility:public"],
     ) for lib in MUSL_LIBS
 ]

--- a/third_party/llvm-project/20.x/libunwind/BUILD.tpl
+++ b/third_party/llvm-project/20.x/libunwind/BUILD.tpl
@@ -1,6 +1,8 @@
 
+
 load("@toolchains_llvm_bootstrapped//toolchain/stage2:cc_stage2_library.bzl", "cc_stage2_library")
 load("@toolchains_llvm_bootstrapped//toolchain/stage2:cc_stage2_static_library.bzl", "cc_stage2_static_library")
+load("@toolchains_llvm_bootstrapped//toolchain/stage2:cc_stage2_shared_library.bzl", "cc_stage2_shared_library")
 
 cc_stage2_library(
     name = "libunwind",
@@ -82,5 +84,14 @@ cc_stage2_static_library(
     deps = [
         ":libunwind",
     ],
+    visibility = ["//visibility:public"],
+)
+
+cc_stage2_shared_library(
+    name = "libunwind.shared",
+    deps = [
+        ":libunwind",
+    ],
+    shared_lib_name = "libunwind.so.1.0",
     visibility = ["//visibility:public"],
 )

--- a/toolchain/args/linux/BUILD.bazel
+++ b/toolchain/args/linux/BUILD.bazel
@@ -136,8 +136,6 @@ cc_args(
         # In prevention of when all of those can be shared libraries.
         "-Wl,--push-state",
         "-Wl,--as-needed",
-        "-lc++",
-        "-lc++abi",
 
         # In newer versions of glibc various libs such as libm, librt are
         # normally included in libc and not available as separate libraries.
@@ -157,7 +155,6 @@ cc_args(
         "-lrt",
         "-lutil",
 
-        "-lunwind", # only if libcxx on linux
         "-Wl,--pop-state",
     ],
     data = [
@@ -234,9 +231,6 @@ cc_args(
         "-Wl,--push-state",
         "-Wl,--as-needed",
 
-        "-lc++",
-        "-lc++abi",
-
         # In newer versions of musl_libc various libs such as libm, librt are
         # normally included in libc and not available as separate libraries.
         #
@@ -250,7 +244,6 @@ cc_args(
         "-lrt",
         "-lutil",
 
-        "-lunwind", # only if libcxx on linux
         "-Wl,--pop-state",
     ],
     data = [

--- a/toolchain/declare_toolchains.bzl
+++ b/toolchain/declare_toolchains.bzl
@@ -16,6 +16,7 @@ def _declare_toolchains(exec_os, exec_cpu):
         name = cc_toolchain_name,
         args = [":toolchain_args"],
         known_features = [
+            "//toolchain/features:static_link_cpp_runtimes",
             "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
             "//toolchain/features:all_non_legacy_builtin_features",
             "//toolchain/features/legacy:all_legacy_builtin_features",
@@ -28,6 +29,7 @@ def _declare_toolchains(exec_os, exec_cpu):
             "//conditions:default": [],
         }),
         enabled_features = [
+            "//toolchain/features:static_link_cpp_runtimes",
             "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
             # Do not enable this manually. Those features are enabled internally by --compilation_mode flags family.
             "//toolchain/features/legacy:all_legacy_builtin_features",
@@ -40,6 +42,8 @@ def _declare_toolchains(exec_os, exec_cpu):
             "//conditions:default": [],
         }),
         tool_map = platform_cc_tool_map(exec_os, exec_cpu),
+        static_runtime_lib = "//runtimes:static_runtime_lib",
+        dynamic_runtime_lib = "//runtimes:dynamic_runtime_lib",
         compiler = "clang",
     )
 

--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -2,13 +2,20 @@ load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
 load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 
+package(default_visibility = ["//visibility:public"])
+
 # [x] opt
 # [x] dbg
 # [] fastbuild
-# [] static_linking_mode
+# [] static_linking_mode - does this do anything? Seems obsolete
 # [] dynamic_linking_mode
 # [] per_object_debug_info
-# [] static_link_cpp_runtimes
+# [x] static_link_cpp_runtimes
+
+cc_feature(
+    name = "static_link_cpp_runtimes",
+    overrides = "@rules_cc//cc/toolchains/features:static_link_cpp_runtimes",
+)
 
 cc_args(
     name = "opt_link_flags",
@@ -101,6 +108,7 @@ cc_feature_set(
     all_of = [
         ":opt",
         ":dbg",
+        ":static_link_cpp_runtimes",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The TL;DR is this lets bazel decide whether to link static or dynamic libc++, libcc++abi, and libunwind, which come from the cc_toolchain. And then we provide empty stub `libc++.a`/etc so that `-lc++` from user-provided flags doesn't error out, though it also has no effect.

This unblocks properly supporting --dynamic_mode flag and scenarios where you link some dylib that dynamically links libc++ so you also want to dynamically link, etc