### PR TITLE
Only add toolchain libs on linux for now

### DIFF
--- a/examples/rules_rust/MODULE.bazel
+++ b/examples/rules_rust/MODULE.bazel
@@ -13,6 +13,13 @@ module(
 # Get latest rules_rust release from:
 # https://github.com/bazelbuild/rules_rust/releases
 bazel_dep(name = "rules_rust", version = "0.67.0")
+single_version_override(
+    module_name = "rules_rust",
+    patch_strip = 1,
+    patches = [
+        "//:toolchain_lib.patch",
+    ],
+)
 
 # https://github.com/bazelbuild/platforms/releases
 bazel_dep(name = "platforms", version = "1.0.0")

--- a/examples/rules_rust/toolchain_lib.patch
+++ b/examples/rules_rust/toolchain_lib.patch
@@ -1,0 +1,73 @@
+commit ac55bf5afc5df708abddb4dfa0284690fdca593e
+Author: David Zbarsky <dzbarsky@gmail.com>
+Date:   Mon Nov 24 20:55:03 2025 -0500
+
+    Add runtime_libs as rust compile action inputs
+
+diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl
+index 48be03504..064de499a 100644
+--- a/rust/private/rustc.bzl
++++ b/rust/private/rustc.bzl
+@@ -727,10 +727,18 @@ def collect_inputs(
+     if linker_script:
+         nolinkstamp_compile_direct_inputs.append(linker_script)
+ 
++    if crate_info.type in ["dylib", "cdylib"]:
++        # For shared libraries we want to link C++ runtime library dynamically
++        # (for example libstdc++.so or libc++.so).
++        runtime_libs = cc_toolchain.dynamic_runtime_lib(feature_configuration = feature_configuration)
++    else:
++        runtime_libs = cc_toolchain.static_runtime_lib(feature_configuration = feature_configuration)
++
+     nolinkstamp_compile_inputs = depset(
+         nolinkstamp_compile_direct_inputs +
+         additional_transitive_inputs,
+         transitive = [
++            runtime_libs,
+             linker_depset,
+             crate_info.srcs,
+             transitive_crate_outputs,
+@@ -2253,36 +2261,22 @@ def _add_native_link_flags(args, dep_info, linkstamp_outs, ambiguous_libs, crate
+ 
+     args.add_all(make_link_flags_args, map_each = make_link_flags)
+ 
+-    args.add_all(linkstamp_outs, before_each = "-C", format_each = "link-args=%s")
++    args.add_all(linkstamp_outs, format_each = "-Clink-args=%s")
+ 
+     if crate_type in ["dylib", "cdylib"]:
+         # For shared libraries we want to link C++ runtime library dynamically
+         # (for example libstdc++.so or libc++.so).
+-        args.add_all(
+-            cc_toolchain.dynamic_runtime_lib(feature_configuration = feature_configuration),
+-            map_each = _get_dirname,
+-            format_each = "-Lnative=%s",
+-        )
++        runtime_libs = cc_toolchain.dynamic_runtime_lib(feature_configuration = feature_configuration)
++        args.add_all(runtime_libs, map_each = _get_dirname, format_each = "-Lnative=%s")
+         if include_link_flags:
+-            args.add_all(
+-                cc_toolchain.dynamic_runtime_lib(feature_configuration = feature_configuration),
+-                map_each = get_lib_name,
+-                format_each = "-ldylib=%s",
+-            )
++            args.add_all(runtime_libs, map_each = get_lib_name, format_each = "-ldylib=%s")
+     else:
+         # For all other crate types we want to link C++ runtime library statically
+         # (for example libstdc++.a or libc++.a).
+-        args.add_all(
+-            cc_toolchain.static_runtime_lib(feature_configuration = feature_configuration),
+-            map_each = _get_dirname,
+-            format_each = "-Lnative=%s",
+-        )
++        runtime_libs = cc_toolchain.static_runtime_lib(feature_configuration = feature_configuration)
++        args.add_all(runtime_libs, map_each = _get_dirname, format_each = "-Lnative=%s")
+         if include_link_flags:
+-            args.add_all(
+-                cc_toolchain.static_runtime_lib(feature_configuration = feature_configuration),
+-                map_each = get_lib_name,
+-                format_each = "-lstatic=%s",
+-            )
++            args.add_all(runtime_libs, map_each = get_lib_name, format_each = "-lstatic=%s")
+ 
+ def _get_dirname(file):
+     """A helper function for `_add_native_link_flags`.

--- a/runtimes/BUILD.bazel
+++ b/runtimes/BUILD.bazel
@@ -8,23 +8,29 @@ alias(
 
 filegroup(
     name = "static_runtime_lib",
-    srcs = [
-        "@libcxx//:libcxx.static",
-        "@libcxxabi//:libcxxabi.static",
-        # only if libcxx on linux
-        "@libunwind//:libunwind.static",
-    ],
+    srcs = select({
+        "@platforms//os:linux": [
+            "@libcxx//:libcxx.static",
+            "@libcxxabi//:libcxxabi.static",
+            ## only if libcxx on linux
+            "@libunwind//:libunwind.static",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//toolchain:__subpackages__"],
 )
 
 filegroup(
     name = "dynamic_runtime_lib",
-    srcs = [
-        "@libcxx//:libcxx.shared",
-        "@libcxxabi//:libcxxabi.shared",
-        # only if libcxx on linux
-        # TODO(zbarsky): Enable this? libunwind depends on a another shared lib which loses GraphNodeInfo provider
-        #"@libunwind//:libunwind.shared",
-    ],
+    srcs = select({
+        "@platforms//os:linux": [
+            "@libcxx//:libcxx.shared",
+            "@libcxxabi//:libcxxabi.shared",
+            # only if libcxx on linux
+            # TODO(zbarsky): Enable this? libunwind depends on a another shared lib which loses GraphNodeInfo provider
+            #"@libunwind//:libunwind.shared",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//toolchain:__subpackages__"],
 )


### PR DESCRIPTION
This restores us to previous behavior where osx comes fully from sysroot. We should fix that, later.

Also adds rules_rust patch that is being upstreamed to get rust builds working again