### PR TITLE
Disable static_link_cpp_runtimes on macOS

### DIFF
--- a/toolchain/args/macos/BUILD.bazel
+++ b/toolchain/args/macos/BUILD.bazel
@@ -47,14 +47,19 @@ cc_args(
     ],
     # -l: is not supported by lld64
     args = [
+        # provides a stub for -lunwind on macOS
+        "-L{libunwind_library_search_path}",
+
         "{libclang_rt.builtins.a}",
         "-lSystem",
     ],
     format = {
         "libclang_rt.builtins.a": "//runtimes/compiler-rt:clang_rt.builtins.static",
+        "libunwind_library_search_path": "//runtimes/libunwind:libunwind_library_search_directory",
     },
     data = [
         "//runtimes/compiler-rt:clang_rt.builtins.static",
+        "//runtimes/libunwind:libunwind_library_search_directory",
     ],
 )
 

--- a/toolchain/declare_toolchains.bzl
+++ b/toolchain/declare_toolchains.bzl
@@ -28,8 +28,12 @@ def _declare_toolchains(exec_os, exec_cpu):
             ],
             "//conditions:default": [],
         }),
-        enabled_features = [
-            "//toolchain/features:static_link_cpp_runtimes",
+        enabled_features = select({
+            "@platforms//os:linux": [
+                "//toolchain/features:static_link_cpp_runtimes",
+            ],
+            "@platforms//os:macos": [],
+        }) + [
             "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
             # Do not enable this manually. Those features are enabled internally by --compilation_mode flags family.
             "//toolchain/features/legacy:all_legacy_builtin_features",


### PR DESCRIPTION
Currently, enabling static_link_cpp_runtimes implies @rules_cc//cc/toolchains/args:static_libgcc:feature which adds -static-libgcc which is not supported by clang as of clang 21.

Here we disable the feature on macOS for now and provide a stub for libunwind (libunwind symbol are included in libSystem).