### PR TITLE
Expose clang builtin headers to cc_toolchain.builtin_include_directories

### DIFF
--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -53,6 +53,7 @@ def declare_llvm_targets(*, suffix = ""):
             ":builtin_headers_include_directory",
         ],
         capabilities = ["@rules_cc//cc/toolchains/capabilities:supports_pic"],
+        allowlist_include_directories = [":builtin_headers_include_directory"],
     )
 
     cc_tool(
@@ -62,6 +63,7 @@ def declare_llvm_targets(*, suffix = ""):
             ":builtin_headers_include_directory",
         ],
         capabilities = ["@rules_cc//cc/toolchains/capabilities:supports_pic"],
+        allowlist_include_directories = [":builtin_headers_include_directory"],
     )
 
     cc_tool(


### PR DESCRIPTION
CC toolchain provider exposes cc_toolchain.built_in_include_directories which is useful in specific scenarios such as zig translate-c when we want to provide a fully explicit set of headers.