### PR TITLE
Remove usage of skylib config_setting_group

### DIFF
--- a/platforms/config/declare_config_settings.bzl
+++ b/platforms/config/declare_config_settings.bzl
@@ -1,13 +1,12 @@
-load("@bazel_skylib//lib:selects.bzl", "selects")
 load("//platforms:common.bzl", _supported_targets = "SUPPORTED_TARGETS")
 
 def declare_config_settings():
     for (target_os, target_cpu) in _supported_targets:
-        selects.config_setting_group(
+        native.config_setting(
             name = "{}_{}".format(target_os, target_cpu),
-            match_all = [
-                "@platforms//cpu:{}".format(target_cpu),
-                "@platforms//os:{}".format(target_os),
+            constraint_values = [
+                "@platforms//cpu:" + target_cpu,
+                "@platforms//os:" + target_os,
             ],
             visibility = ["//visibility:public"],
         )


### PR DESCRIPTION
The skylib macro generates some crazy multilevel alias goop, we don't need any of it