### PR TITLE
Add libc_nonshared.a throught the libc.so linker script

### DIFF
--- a/runtimes/glibc/BUILD.bazel
+++ b/runtimes/glibc/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//toolchain:selects.bzl", "platform_extra_binary")
@@ -114,12 +115,25 @@ LINKER_SCRIPTS = [
         name = "lib%s_linker_script" % lib,
         lib_name = lib,
         lib_version = version,
+        additional_linker_inputs = [
+            # we make it available in the search directory sibling to the libc.so
+            "libc_nonshared.a",
+        ] if lib == "c" else [],
     ) for (lib, version) in LIBC_SO_VERSIONS.items()
 ]
 
+copy_file(
+    name = "glibc_libc_nonshared.static",
+    src = "@glibc//:glibc_c_nonshared.static",
+    out = "libc_nonshared.a",
+    allow_symlink = True,
+)
+
 copy_to_directory(
     name = "glibc_library_search_directory",
-    srcs = LIBS + LINKER_SCRIPTS,
+    srcs = LIBS + LINKER_SCRIPTS + [
+        "libc_nonshared.a",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -132,11 +146,5 @@ alias(
 alias(
     name = "glibc_Scrt1.static",
     actual = "@glibc//:glibc_Scrt1.static",
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "glibc_libc_nonshared.static",
-    actual = "@glibc//:c_nonshared.static",
     visibility = ["//visibility:public"],
 )

--- a/runtimes/glibc/extension/BUILD.trampoline.tpl
+++ b/runtimes/glibc/extension/BUILD.trampoline.tpl
@@ -13,8 +13,8 @@ alias(
 )
 
 alias(
-    name = "c_nonshared.static",
-    actual = make_select_glibc_repository_target("@glibc", "c_nonshared.static"),
+    name = "glibc_c_nonshared.static",
+    actual = make_select_glibc_repository_target("@glibc", "c_nonshared"),
 )
 
 alias(

--- a/runtimes/glibc/glibc_linker_script.bzl
+++ b/runtimes/glibc/glibc_linker_script.bzl
@@ -1,8 +1,13 @@
-def make_glibc_linker_script(name, lib_name, lib_version):
+def make_glibc_linker_script(name, lib_name, lib_version, additional_linker_inputs = []):
     native.genrule(
         name = name,
         srcs = [],
         outs = ["lib{lib}.so".format(lib = lib_name)],
-        cmd = "echo 'INPUT(lib{lib}.so.{version})' > $@".format(lib = lib_name, version = lib_version),
+        # GROUP(file) is the same as INPUT(file) when there is just one file.
+        cmd = """echo 'GROUP(lib{lib}.so.{version} {extra_inputs})' > $@""".format(
+            lib = lib_name,
+            version = lib_version,
+            extra_inputs = " ".join(additional_linker_inputs),
+        ),
     )
     return name

--- a/third_party/libc/glibc/BUILD.tpl
+++ b/third_party/libc/glibc/BUILD.tpl
@@ -174,8 +174,7 @@ cc_stage2_static_library(
 # }
 
 cc_stage2_library(
-    # glibc_c_nonshared
-    name = "c_nonshared",
+    name = "glibc_c_nonshared",
     copts = [
         "-std=gnu11",
         "-fgnu89-inline",
@@ -280,9 +279,9 @@ cc_stage2_library(
 )
 
 cc_stage2_static_library(
-    name = "c_nonshared.static",
+    name = "c_nonshared",
     deps = [
-        ":c_nonshared",
+        ":glibc_c_nonshared",
     ],
     visibility = ["//visibility:public"],
 )

--- a/toolchain/args/linux/BUILD.bazel
+++ b/toolchain/args/linux/BUILD.bazel
@@ -145,12 +145,7 @@ cc_args(
         # handle varying inclusions.
         "-lm",
         "-lpthread",
-
         "-lc",
-        # In real life, libc_nonshared is added the libc.so linker script right 
-        # after the libc.so.6 library.
-        "{libc_nonshared.a}",
-
         "-ldl",
         "-lrt",
         "-lutil",
@@ -160,14 +155,12 @@ cc_args(
     data = [
         "//runtimes/compiler-rt:clang_rt.builtins.static",
         "//runtimes/libcxx:libcxx_library_search_directory",
-        "//runtimes/glibc:glibc_libc_nonshared.static",
         "//runtimes/glibc:glibc_library_search_directory",
         "//runtimes/libunwind:libunwind_library_search_directory",
     ],
     format = {
         "clang_rt.builtins.a": "//runtimes/compiler-rt:clang_rt.builtins.static",
         "libcxx_library_search_path": "//runtimes/libcxx:libcxx_library_search_directory",
-        "libc_nonshared.a": "//runtimes/glibc:glibc_libc_nonshared.static",
         "libc_library_search_path": "//runtimes/glibc:glibc_library_search_directory",
         "libunwind_library_search_path": "//runtimes/libunwind:libunwind_library_search_directory",
     },


### PR DESCRIPTION
As it was intented to be!

FYI this is what the official linker script for libc.so is:

```
/* GNU ld script
   Use the shared library, but some functions are only in
   the static library, so try that secondarily.  */
OUTPUT_FORMAT(elf64-littleaarch64)
GROUP ( /lib/aarch64-linux-gnu/libc.so.6 /usr/lib/aarch64-linux-gnu/libc_nonshared.a  AS_NEEDED ( /lib/ld-linux-aarch64.so.1 ) )
```