### PR TITLE
Adjust supported exec platforms for stage1

### DIFF
--- a/toolchain/stage1/declare_toolchains.bzl
+++ b/toolchain/stage1/declare_toolchains.bzl
@@ -4,6 +4,9 @@ load("//toolchain:cc_toolchain.bzl", "cc_toolchain")
 def declare_toolchains():
     supported_execs = [
         (arch, os)
+        # Any supported target that can run a compiler is a supported exec.
+        # If we can compile a compiler for that target, we can use that compiler
+        # to compile for any other target.
         for (arch, os) in SUPPORTED_TARGETS
         if arch != "none" # wasm is no good for us.
     ]


### PR DESCRIPTION
Fundamentally any supported target that can run a compiler becomes a valid stage1 exec