### PR TITLE
Disable cross-compilation test suite for windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,8 +85,8 @@ jobs:
         bazel_version: [last_rc]
         folder:
           - "e2e/rules_cc"
-          #- "e2e/rules_rust"
-          - "e2e/cross_compilation"
+          # - "e2e/rules_rust"
+          # - "e2e/cross_compilation"
           # - "e2e/wasm"
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
First we need to obliterate the genrules from musl targets