### PR TITLE
Enable remote repo contents cache on windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,26 +96,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Cache build and external artifacts so that the next ci build is incremental.
-      # Because github action caches cannot be updated after a build, we need to
-      # store the contents of each build in a unique cache key, then fall back to loading
-      # it on the next ci run. We use hashFiles(...) in the key and restore-keys- with
-      # the prefix to load the most recent cache for the branch on a cache miss. You
-      # should customize the contents of hashFiles to capture any bazel input sources,
-      # although this doesn't need to be perfect. If none of the input sources change
-      # then a cache hit will load an existing cache and bazel won't have to do any work.
-      # In the case of a cache miss, you want the fallback cache to contain most of the
-      # previously built artifacts to minimize build time. The more precise you are with
-      # hashFiles sources the less work bazel will have to do.
-      - name: Mount bazel caches
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/bazel-repo
-          key: bazel-cache-${{ matrix.os }}-${{ matrix.bazel_version }}-${{ matrix.folder }}-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', 'MODULE.bazel') }}
-          restore-keys: |
-            bazel-cache-${{ matrix.os }}-${{ matrix.bazel_version }}-${{ matrix.folder }}
-
       - name: bazel test //...
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
@@ -134,7 +114,10 @@ jobs:
           bazel \
             --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc \
             --bazelrc=.bazelrc \
+            --experimental_remote_repo_contents_cache \
             test \
+            --repository_cache= \
+            --repo_contents_cache= \
             --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY \
             --config=stage1 \
             $EXTRA_ARGS \


### PR DESCRIPTION
Since we only run bazel9rc here, we can enable this. It's even better than saving/restoring repo caches