### PR TITLE
Fix libc default constraint

### DIFF
--- a/constraints/libc/BUILD.bazel
+++ b/constraints/libc/BUILD.bazel
@@ -4,9 +4,13 @@ package(default_visibility = ["//visibility:public"])
 
 constraint_setting(
     name = "variant",
-    # This is a hard default for users of this toolchain using their own
-    # platforms that do not specify a libc variant.
-    default_constraint_value = "gnu.2.28",
+    # For linux, this maps to a default gnu.2.28
+    default_constraint_value = "unconstrained",
+)
+
+constraint_value(
+    name = "unconstrained",
+    constraint_setting = "variant",
 )
 
 declare_libcs_constraints()

--- a/constraints/libc/libc_versions.bzl
+++ b/constraints/libc/libc_versions.bzl
@@ -20,3 +20,4 @@ GLIBCS = ["gnu.{}".format(glibc) for glibc in GLIBC_VERSIONS]
 
 LIBCS = ["musl"] + GLIBCS
 
+DEFAULT_LIBC = "gnu.2.28"

--- a/kernel/extension/libc_kernel_versions.bzl
+++ b/kernel/extension/libc_kernel_versions.bzl
@@ -29,3 +29,5 @@ LIBC_KERNEL_VERSIONS = {
     "gnu.2.42": "6.16.12",
     "musl"    : "6.16.12", # Latest for musl always
 }
+
+LIBC_KERNEL_VERSIONS["unconstrained"] = LIBC_KERNEL_VERSIONS["gnu.2.28"]

--- a/kernel/extension/make_select_kernel_headers_repository_target.bzl
+++ b/kernel/extension/make_select_kernel_headers_repository_target.bzl
@@ -7,7 +7,7 @@ def make_select_kernel_headers_repository_target(bazel_target):
     """Select the right kernel headers repository based on the target architecture and the libc version."""
     selection = {}
     for (target_os, target_arch) in LIBC_SUPPORTED_TARGETS:
-        for libc_version in LIBCS:
+        for libc_version in LIBCS + ["unconstrained"]:
             kernel_version = LIBC_KERNEL_VERSIONS[libc_version]
             apparent_target = "@linux_kernel_headers_{}.{}//:{}".format(arch_to_kernel_arch(target_arch), kernel_version, bazel_target)
             selection["@toolchains_llvm_bootstrapped//platforms/config:{}_{}_{}".format(target_os, target_arch, libc_version)] = apparent_target

--- a/platforms/config/declare_config_settings.bzl
+++ b/platforms/config/declare_config_settings.bzl
@@ -1,6 +1,6 @@
 load("//platforms:common.bzl", "SUPPORTED_TARGETS", "LIBC_SUPPORTED_TARGETS")
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load("//constraints/libc:libc_versions.bzl", _libc_versions = "LIBCS", _glibc_versions = "GLIBCS")
+load("//constraints/libc:libc_versions.bzl", "LIBCS", "GLIBCS")
 
 def declare_config_settings():
     for (target_os, target_cpu) in SUPPORTED_TARGETS:
@@ -17,7 +17,7 @@ def declare_config_settings():
 
 def declare_config_settings_libc_aware():
     for (target_os, target_cpu) in LIBC_SUPPORTED_TARGETS:
-        for libc in _libc_versions:
+        for libc in LIBCS + ["unconstrained"]:
             native.config_setting(
                 name = "{}_{}_{}".format(target_os, target_cpu, libc),
                 constraint_values = [
@@ -41,7 +41,10 @@ def declare_config_settings_libc_aware():
     selects.config_setting_group(
         name = "gnu",
         match_any = [
-            "//constraints/libc:{}".format(libc) for libc in _glibc_versions
+            "//constraints/libc:{}".format(libc) for libc in GLIBCS
+        ] + [
+            "{}_{}_unconstrained".format(target_os, target_cpu)
+            for (target_os, target_cpu) in LIBC_SUPPORTED_TARGETS
         ],
         visibility = ["//visibility:public"],
     )

--- a/runtimes/glibc/extension/make_select_glibc_repository_target.bzl
+++ b/runtimes/glibc/extension/make_select_glibc_repository_target.bzl
@@ -1,11 +1,12 @@
-load("//constraints/libc:libc_versions.bzl", "GLIBCS")
+load("//constraints/libc:libc_versions.bzl", "GLIBCS", "DEFAULT_LIBC")
 load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
 
 def make_select_glibc_repository_target(bazel_repository, bazel_target):
     selection = {}
     for (target_os, target_arch) in LIBC_SUPPORTED_TARGETS:
-        for libc_version in GLIBCS:
-            apparent_target = "{}_{}-{}-{}//:{}".format(bazel_repository, target_arch, target_os, libc_version, bazel_target)
+        for libc_version in GLIBCS + ["unconstrained"]:
+            apparent_libc_version_suffix = libc_version if libc_version != "unconstrained" else DEFAULT_LIBC
+            apparent_target = "{}_{}-{}-{}//:{}".format(bazel_repository, target_arch, target_os, apparent_libc_version_suffix, bazel_target)
             selection["@toolchains_llvm_bootstrapped//platforms/config:{}_{}_{}".format(target_os, target_arch, libc_version)] = apparent_target
 
     return select(selection)

--- a/runtimes/glibc/libc_aware_target_triple.bzl
+++ b/runtimes/glibc/libc_aware_target_triple.bzl
@@ -1,12 +1,13 @@
-load("//constraints/libc:libc_versions.bzl", _libc_versions = "LIBCS")
-load("//platforms:common.bzl", _libc_supported_targets = "LIBC_SUPPORTED_TARGETS")
+load("//constraints/libc:libc_versions.bzl", "LIBCS", "DEFAULT_LIBC")
+load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
 
 # For use with zig tools that consume parse zig targets triples
 # Zig target triples only, not LLVM
 def libc_aware_target_triple():
     target = {}
-    for (target_os, target_cpu) in _libc_supported_targets:
-        for libc_version in _libc_versions:
-            target["//platforms/config:{}_{}_{}".format(target_os, target_cpu, libc_version)] = "{}-{}-{}".format(target_cpu, target_os, libc_version)
+    for (target_os, target_cpu) in LIBC_SUPPORTED_TARGETS:
+        for libc_version in LIBCS + ["unconstrained"]:
+            target_libc_suffix = libc_version if libc_version != "unconstrained" else DEFAULT_LIBC
+            target["//platforms/config:{}_{}_{}".format(target_os, target_cpu, libc_version)] = "{}-{}-{}".format(target_cpu, target_os, target_libc_suffix)
 
     return select(target)

--- a/third_party/libc/glibc/BUILD.tpl
+++ b/third_party/libc/glibc/BUILD.tpl
@@ -246,6 +246,10 @@ cc_stage2_library(
     ] + selects.with_or({
         (
             # For now the minimum version of all supported platforms is glibc 2.28
+            #
+            # unconstrained defaults to 2.28
+            # TODO(cerisier): Make a is_at_least_gnu_version macro helper.
+            "@toolchains_llvm_bootstrapped//constraints/libc:unconstrained",
             "@toolchains_llvm_bootstrapped//constraints/libc:gnu.2.28",
             "@toolchains_llvm_bootstrapped//constraints/libc:gnu.2.29",
             "@toolchains_llvm_bootstrapped//constraints/libc:gnu.2.30",


### PR DESCRIPTION
Having a build_setting_default effectively makes this part of the configuration.
So we still have to differentiate between unconstrained and an explicit value.

That way, I can now say that "gnu" is any glibc version that is explicit + any linux with libc constraint to unconstrained.