### PR TITLE
Do not register stage1 toolchain by default for prebuilts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,7 +33,7 @@ common:prebuilt  --copt=-fno-exceptions
 common:prebuilt  --copt=-fno-rtti
 common:prebuilt  --copt=-fomit-frame-pointer
 common:prebuilt  --dynamic_mode=off
-common:prebuilt  --extra_toolchains=//toolchain/...
+common:prebuilt  --extra_toolchains=//toolchain:all
 
 common:rust    --@toolchains_llvm_bootstrapped//config:experimental_stub_libgcc_s=True
 common:rust    --@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos=False


### PR DESCRIPTION
Otherwise we build llvm to build llvm