### PR TITLE
Enable ICF in opt linking

### DIFF
--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -31,6 +31,10 @@ cc_args(
             #TODO: should be somehow done only if the choosen linker supports it
             "-Wl,--gc-sections",
         ],
+    }) + select({
+        "@platforms//cpu:wasm32": [],
+        "@platforms//cpu:wasm64": [],
+        "//conditions:default": ["-Wl,--icf=safe"],
     }),
 )
 


### PR DESCRIPTION
This removes around 5-10% of binary size