### PR TITLE
Allow configuring custom OSX sysroots

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,5 +119,6 @@ jobs:
             --repository_cache= \
             --repo_contents_cache= \
             --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY \
+            --jobs=100 \
             $EXTRA_ARGS \
             //...

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -96,19 +96,8 @@ use_repo(musl, "musl_libc")
 mingw = use_extension("//runtimes/mingw/extension:mingw.bzl", "mingw")
 use_repo(mingw, "mingw")
 
-http_pkg_archive = use_repo_rule("//:http_pkg_archive.bzl", "http_pkg_archive")
-
-http_pkg_archive(
-    name = "macosx15.4.sdk",
-    build_file = "//third_party/macosx.sdk:BUILD.MacOSX15.4.sdk.tpl",
-    sha256 = "ba3453d62b3d2babf67f3a4a44e8073d6555c85f114856f4390a1f53bd76e24a",
-    strip_files = [
-        "Library/Developer/CommandLineTools/SDKs/MacOSX15.5.sdk/System/Library/Frameworks/Ruby.framework/Versions/Current/Headers/ruby",
-    ],
-    strip_prefix = "Library/Developer/CommandLineTools/SDKs/MacOSX15.5.sdk",
-    # urls = ["https://swcdn.apple.com/content/downloads/10/32/082-12052-A_AHPGDY76PT/1a419zaf3vh8o9t3c0usblyr8eystpnsh5/CLTools_macOSNMOS_SDK.pkg"],
-    urls = ["https://swcdn.apple.com/content/downloads/52/01/082-41241-A_0747ZN8FHV/dectd075r63pppkkzsb75qk61s0lfee22j/CLTools_macOSNMOS_SDK.pkg"],
-)
+osx = use_extension("//toolchain/extension:osx.bzl", "osx")
+use_repo(osx, "macosx15.4.sdk")
 
 glibc = use_extension("//runtimes/glibc/extension:glibc.bzl", "glibc")
 

--- a/third_party/macosx.sdk/BUILD.MacOSX15.4.sdk.tpl
+++ b/third_party/macosx.sdk/BUILD.MacOSX15.4.sdk.tpl
@@ -33,32 +33,13 @@ COMMON_EXCLUDES = [
     "usr/include/tidy/**",
 ])
 
-directory(
-    name = "sysroot",
-    srcs = glob(["*/**"], exclude = COMMON_EXCLUDES + glob([
-        "System/Library/Frameworks/Ruby.framework/**",
-        "System/Cryptexes/**",
-        "System/iOSSupport/**",
-        "System/Library/CoreServices/**",
-        "System/Library/Perl/**",
-        "System/Library/PrivateFrameworks/**",
-    ])),
-    visibility = ["//visibility:public"],
-)
-
 # Sandboxing the entire macOS SDK dramatically slows down the build process.
 # Offering a minimal sysroot allows for building basic cross platform applications.
-# We may selectively add more entries to it as needed. 
+# Users can extend the sysroot via `osx.framework` module extension tags.
 directory(
-    name = "sysroot-minimal",
+    name = "sysroot",
     srcs = glob([
-        # Opinionated list of frameworks for minimal macOS SDK.
-        "System/Library/Frameworks/CoreFoundation.framework/**",
-        "System/Library/Frameworks/Foundation.framework/**",
-        "System/Library/Frameworks/Kernel.framework/**",
-        "System/Library/Frameworks/OSLog.framework/**",
-        "System/Library/Frameworks/Security.framework/**",
-        "System/Library/Frameworks/SystemConfiguration.framework/**",
+{frameworks}
 
         "usr/**",
     ], exclude = COMMON_EXCLUDES),

--- a/toolchain/args/macos/BUILD.bazel
+++ b/toolchain/args/macos/BUILD.bazel
@@ -6,9 +6,9 @@ package(default_visibility = ["//visibility:public"])
 
 cc_sysroot(
     name = "macos_sdk_sysroot",
-    sysroot = "@macosx15.4.sdk//:sysroot-minimal",
+    sysroot = "@macosx15.4.sdk//:sysroot",
     data = [
-        "@macosx15.4.sdk//:sysroot-minimal",
+        "@macosx15.4.sdk//:sysroot",
     ],
 )
 

--- a/toolchain/extension/osx.bzl
+++ b/toolchain/extension/osx.bzl
@@ -1,0 +1,54 @@
+load("//:http_pkg_archive.bzl", "http_pkg_archive")
+
+# Opinionated list of frameworks for minimal macOS SDK.
+_DEFAULT_FRAMEWORKS = [
+    "CoreFoundation",
+    "Foundation",
+    "Kernel",
+    "OSLog",
+    "Security",
+    "SystemConfiguration",
+]
+
+def _osx_extension_impl(mctx):
+    frameworks = []
+
+    for module in mctx.modules:
+        for framework_tag in module.tags.framework:
+            frameworks.append(framework_tag.name)
+
+    if not frameworks:
+        frameworks = _DEFAULT_FRAMEWORKS
+
+
+    build_file_content = mctx.read(Label("//third_party/macosx.sdk:BUILD.MacOSX15.4.sdk.tpl"))
+    build_file_content = build_file_content.replace(
+        "{frameworks}",
+        "\n".join(['       "System/Library/Frameworks/%s.framework/**",' % framework for framework in frameworks]))
+
+    http_pkg_archive(
+        name = "macosx15.4.sdk",
+        build_file_content = build_file_content,
+        sha256 = "ba3453d62b3d2babf67f3a4a44e8073d6555c85f114856f4390a1f53bd76e24a",
+        strip_files = [
+            "Library/Developer/CommandLineTools/SDKs/MacOSX15.5.sdk/System/Library/Frameworks/Ruby.framework/Versions/Current/Headers/ruby",
+        ],
+        strip_prefix = "Library/Developer/CommandLineTools/SDKs/MacOSX15.5.sdk",
+        # urls = ["https://swcdn.apple.com/content/downloads/10/32/082-12052-A_AHPGDY76PT/1a419zaf3vh8o9t3c0usblyr8eystpnsh5/CLTools_macOSNMOS_SDK.pkg"],
+        urls = ["https://swcdn.apple.com/content/downloads/52/01/082-41241-A_0747ZN8FHV/dectd075r63pppkkzsb75qk61s0lfee22j/CLTools_macOSNMOS_SDK.pkg"],
+    )
+
+_framework_tag = tag_class(
+    attrs = {
+        "name": attr.string(mandatory = True),
+    },
+)
+
+osx = module_extension(
+    implementation = _osx_extension_impl,
+    doc = "Generates an OSX sysroot with the requested set of frameworks (or a reasonable default)",
+    tag_classes = {
+        "framework": _framework_tag,
+    },
+)
+


### PR DESCRIPTION
Usage like so:

```
bazel_dep(name = "toolchains_llvm_bootstrapped", version = "0.3.1")
local_path_override(
    module_name = "toolchains_llvm_bootstrapped",
    path = "../toolchains_llvm_bootstrapped",
)
osx = use_extension("//toolchain/extension:osx.bzl", "osx")

osx.framework(name = "ApplicationServices")
osx.framework(name = "AppKit")
osx.framework(name = "ColorSync")
osx.framework(name = "CoreFoundation")
osx.framework(name = "CoreGraphics")
osx.framework(name = "CoreServices")
osx.framework(name = "CoreText")
osx.framework(name = "CFNetwork")
osx.framework(name = "Foundation")
osx.framework(name = "ImageIO")
osx.framework(name = "Kernel")
osx.framework(name = "OSLog")
osx.framework(name = "Security")
osx.framework(name = "SystemConfiguration")
```
