### PR TITLE
[osx] Include device headers

### DIFF
--- a/third_party/macosx.sdk/BUILD.MacOSX15.4.sdk.tpl
+++ b/third_party/macosx.sdk/BUILD.MacOSX15.4.sdk.tpl
@@ -20,7 +20,6 @@ COMMON_EXCLUDES = [
     "usr/include/bank/**",
     "usr/include/cups/**",
     "usr/include/default_pager/**",
-    "usr/include/device/**",
     "usr/include/EndpointSecurity/**",
     "usr/include/libDER/**",
     "usr/include/libexslt/**",


### PR DESCRIPTION
It's used internally

```
In file included from external/toolchains_llvm_bootstrapped++osx+macosx15.4.sdk/System/Library/Frameworks/CoreServices.framework/Headers/CoreServices.h:23:
In file included from external/toolchains_llvm_bootstrapped++osx+macosx15.4.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/AE.framework/Headers/AE.h:20:
In file included from external/toolchains_llvm_bootstrapped++osx+macosx15.4.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/CarbonCore.h:87:
In file included from external/toolchains_llvm_bootstrapped++osx+macosx15.4.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Components.h:26:
In file included from external/toolchains_llvm_bootstrapped++osx+macosx15.4.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Files.h:56:
In file included from external/toolchains_llvm_bootstrapped++osx+macosx15.4.sdk/System/Library/Frameworks/DiskArbitration.framework/Headers/DADisk.h:28:
In file included from external/toolchains_llvm_bootstrapped++osx+macosx15.4.sdk/System/Library/Frameworks/IOKit.framework/Headers/IOKitLib.h:49:
external/toolchains_llvm_bootstrapped++osx+macosx15.4.sdk/System/Library/Frameworks/IOKit.framework/Headers/IOTypes.h:176:10: fatal error: 'device/device_types.h' file not found
  176 | #include <device/device_types.h>
```