### PR TITLE
[compiler-rt] Fix builtin source file dedup

### DIFF
--- a/third_party/llvm-project/20.x/compiler-rt/filter_builtin_sources.bzl
+++ b/third_party/llvm-project/20.x/compiler-rt/filter_builtin_sources.bzl
@@ -37,9 +37,10 @@ def _filter_builtin_sources_impl(ctx):
                     break
 
         if not excluded:
-            basename_to_file[f.basename] = f
+            basename = f.basename[:-(len(f.extension) + 1)]
+            basename_to_file[basename] = f
 
-    # Only keep the last occurrence for each basename
+    # Only keep the last occurrence for each basename (without extension)
     unique_files = list(basename_to_file.values())
 
     return [


### PR DESCRIPTION
The deduplication must be done based on the basename without extension.

This is actually an important bug because the linker pulls the first symbol it sees from the archive that contains both.

When compiling gcc_s.so this surfaced as a duplicate symbol.