### PR TITLE
Support FDO/CSFDO

### DIFF
--- a/runtimes/BUILD.bazel
+++ b/runtimes/BUILD.bazel
@@ -170,6 +170,11 @@ copy_to_resource_directory(
             "//runtimes/compiler-rt:clang_rt.ubsan.static": "libclang_rt.ubsan_standalone",
         },
         "//conditions:default": {},
+    }) | select({
+        "@platforms//os:none": {},
+        "//conditions:default": {
+            "//runtimes/compiler-rt:clang_rt.profile.static": "libclang_rt.profile",
+        },
     }),
     visibility = ["//visibility:public"],
 )

--- a/runtimes/compiler-rt/BUILD.bazel
+++ b/runtimes/compiler-rt/BUILD.bazel
@@ -5,6 +5,12 @@ alias(
 )
 
 alias(
+    name = "clang_rt.profile.static",
+    actual = "@compiler-rt//:clang_rt.profile.static",
+    visibility = ["//visibility:public"],
+)
+
+alias(
     name = "clang_rt.ubsan.static",
     actual = "@compiler-rt//:ubsan.static",
     visibility = ["//visibility:public"],

--- a/toolchain/runtimes/cc_runtime_shared_library.bzl
+++ b/toolchain/runtimes/cc_runtime_shared_library.bzl
@@ -8,6 +8,9 @@ _builder = with_cfg(
     extra_providers = [CcSharedLibraryInfo],
 )
 
+# Avoid dependency on libclang_rt.profile.a
+_builder.extend("features", ["-fdo_instrument", "-cs_fdo_instrument"])
+
 cc_runtime_stage0_shared_library, _cc_stage0_shared_library_internal = configure_builder_for_runtimes(_builder.clone(), "stage0", "dynamic").build()
 cc_runtime_stage1_shared_library, _cc_stage1_shared_library_internal = configure_builder_for_runtimes(_builder.clone(), "stage1", "dynamic").build()
 cc_runtime_stage2_shared_library, _cc_stage2_shared_library_internal = configure_builder_for_runtimes(_builder.clone(), "stage2", "dynamic").build()

--- a/toolchain/runtimes/cc_runtime_static_library.bzl
+++ b/toolchain/runtimes/cc_runtime_static_library.bzl
@@ -6,6 +6,9 @@ _builder = with_cfg(
     cc_static_library,
 )
 
+# Static library doesn't support these.
+_builder.extend("features", ["-fdo_instrument", "-cs_fdo_instrument"])
+
 # NOTE: runtime static libraries do not have >stage0 dependencies.
 # Those are only needed for shared libraries.
 cc_runtime_stage0_static_library, _cc_stage0_static_library_internal = configure_builder_for_runtimes(_builder.clone(), "stage0").build()


### PR DESCRIPTION
This won't work on OSX because of lack of resource_dir.

It would have been nice to avoid building profile lib when these flags aren't set, but it seems hard (maybe impossible?) to do properly because we'd need to check if the features are enabled to properly add it in, and checking that requires the toolchain itself :)