### PR TITLE
Add remote exec platform for musl

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,6 +52,7 @@ common --grpc_keepalive_time=30s
 common:remote --remote_executor=grpcs://remote.buildbuddy.io
 common:remote --jobs=800
 common:remote --extra_execution_platforms=@toolchains_llvm_bootstrapped//:rbe_platform
+common:remote --extra_execution_platforms=@toolchains_llvm_bootstrapped//:rbe_platform_musl
 
 # Load any settings specific to the current user.
 # .bazelrc.user should appear in .gitignore so that settings are not shared with team members

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,7 +6,19 @@ platform(
         # ubuntu:22.04 has GNU C Library (Ubuntu GLIBC 2.35-0ubuntu3.10)
         # But apparently not in this docker://ubuntu:22.04 image?
         "@toolchains_llvm_bootstrapped//constraints/libc:gnu.2.28",
-        "@bazel_tools//tools/cpp:clang",
+    ],
+    exec_properties = {
+        "container-image": "docker://ubuntu:22.04",
+        "OSFamily": "Linux",
+    },
+)
+
+platform(
+    name = "rbe_platform_musl",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+        "@toolchains_llvm_bootstrapped//constraints/libc:musl",
     ],
     exec_properties = {
         "container-image": "docker://ubuntu:22.04",


### PR DESCRIPTION
Allows running musl-built tests remotely.

```
➜  hermetic-launcher git:(bazelify) ✗ bazel test //... --config=remote  --platforms=@toolchains_llvm_bootstrapped//platforms:linux_amd64_musl --extra_execution_platforms=@toolchains_llvm_bootstrapped//:rbe_platform 
INFO: Invocation ID: 0025d1b0-f3f0-4689-a43e-f8495fbdb7b3
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/0025d1b0-f3f0-4689-a43e-f8495fbdb7b3
ERROR: /Users/dzbarsky/hermetic-launcher/integration-tests/BUILD.bazel:55:8: While resolving toolchains for target //integration-tests:integration_test (99c3c5a): No matching toolchains found for types:
  @@bazel_tools//tools/test:default_test_toolchain_type: By default, tests are executed on the first execution platform that matches all 
```