### PR TITLE
Disable compiling from Windows ARM64 hosts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-11-arm]
+        # Add windows-11-arm when bazel supports it better.
+        os: [windows-latest]
         bazel_version: [last_rc]
         folder:
           - "e2e/rules_cc"
@@ -102,7 +103,6 @@ jobs:
 
       - name: bazel test //...
         id: bazel_test
-        continue-on-error: ${{ matrix.os == 'windows-11-arm' }}
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -128,10 +128,3 @@ jobs:
             --jobs=100 \
             $EXTRA_ARGS \
             //...
-
-      - name: "Skip failures on Windows ARM"
-        if: ${{ matrix.os == 'windows-11-arm' && steps.bazel_test.outcome == 'failure' }}
-        run: |
-          echo "::warning title=Windows ARM tests::Known flakiness; ignoring failures for now."
-          echo "### Windows ARM" >> "$GITHUB_STEP_SUMMARY"
-          echo "Tests failed but were ignored (best-effort)." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Bazel has issues running there anyway.
And we also need to fix LZMA support for windows arm64.