### PR TITLE
Enable all multicall tools

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,7 +34,7 @@ common:prebuilt  --copt=-fomit-frame-pointer
 common:prebuilt  --dynamic_mode=off
 common:prebuilt  --extra_toolchains=//toolchain:all
 # See https://github.com/llvm/llvm-project/blob/497a6d672263343f58eae5a5e697484f4899fbdc/utils/bazel/llvm-project-overlay/llvm/driver.bzl#L11
-common:prebuilt --@llvm-project//llvm:driver-tools=clang-scan-deps,clang,dsymutil,lld,llvm-ar,llvm-cxxfilt,llvm-libtool-darwin,llvm-nm,llvm-objcopy,llvm-size,llvm-symbolizer
+common:prebuilt --@llvm-project//llvm:driver-tools=clang-scan-deps,clang,dsymutil,lld,llvm-ar,llvm-cgdata,llvm-cxxfilt,llvm-debuginfod-find,llvm-dwp,llvm-gsymutil,llvm-ifs,llvm-libtool-darwin,llvm-lipo,llvm-ml,llvm-mt,llvm-nm,llvm-objcopy,llvm-objdump,llvm-rc,llvm-readobj,llvm-size,llvm-symbolizer,sancov
 
 common:rust    --@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos=False
 common:rust    --@rules_rust//rust/settings:experimental_use_sh_toolchain_for_bootstrap_process_wrapper


### PR DESCRIPTION
I wanted `llvm-dwp` to support `--fission=yes` but figured we might as well enable all tools if we're going to cut a new release anyway. This adds around 900kb to our dists (on Mac, didn't measure the others but probably similarish)