### PR TITLE
Avoid eternal remote cache timeouts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -46,7 +46,7 @@ common --remote_cache=grpcs://remote.buildbuddy.io
 common --remote_cache_compression
 common --remote_download_toplevel
 common --nobuild_runfile_links
-common --remote_timeout=3600
+common --remote_timeout=120
 common --noexperimental_throttle_remote_action_building
 common --experimental_remote_execution_keepalive
 common --grpc_keepalive_time=30s

--- a/tools/preset.bazelrc
+++ b/tools/preset.bazelrc
@@ -135,10 +135,6 @@ common:ci --remote_download_outputs="minimal"
 common:ci --remote_local_fallback
 # Docs: https://registry.build/flag/bazel?filter=remote_local_fallback
 
-# On CI, extend the maximum amount of time to wait for remote execution and cache calls.
-common:ci --remote_timeout=3600
-# Docs: https://registry.build/flag/bazel?filter=remote_timeout
-
 # Do not upload locally executed action results to the remote cache.
 # This should be the default for local builds so local builds cannot poison the remote cache.
 #


### PR DESCRIPTION
From local testing it appears our long linking action does not get interrupted by this timeout, so hopefully this is OK and fixes our stalled builds