### PR TITLE
Only pass `--unwindlib=none` for executable link actions

### DIFF
--- a/toolchain/args/BUILD.bazel
+++ b/toolchain/args/BUILD.bazel
@@ -711,7 +711,7 @@ cc_args(
 cc_args(
     name = "unwindlib_none",
     actions = [
-        "@rules_cc//cc/toolchains/actions:link_actions",
+        "@rules_cc//cc/toolchains/actions:link_executable_actions",
     ],
     args = [
         # will prevent clang to choose which libunwind to link against


### PR DESCRIPTION
Silences this warning encountered when building Bazel:
```
INFO: From Linking external/zstd-jni+/libzstd-jni.so [for tool]:
clang++: warning: argument unused during compilation: '--unwindlib=none' [-Wunused-command-line-argument]
```