### PR TITLE
Add the `--macos_minimum_os` version used by Bazel

### DIFF
--- a/toolchain/args/macos/macos_minimum_os_flag.bzl
+++ b/toolchain/args/macos/macos_minimum_os_flag.bzl
@@ -1,4 +1,5 @@
 MACOS_MINIMUM_OS_VERSIONS = [
+    "10.13",
     "13.0",
     "13.1",
     "13.2",


### PR DESCRIPTION
A very old version that makes it possible to build Bazel without changes: https://github.com/bazelbuild/bazel/blob/cdaaf5e1b095dfb63bfaebeb67ecacb543ac949b/.bazelrc#L26