### PR TITLE
Add -Werror=incomplete-umbrella always

### DIFF
--- a/toolchain/args/BUILD.bazel
+++ b/toolchain/args/BUILD.bazel
@@ -58,6 +58,8 @@ cc_args(
         "-Xclang",
         "-fno-cxx-modules",
         "-Wno-module-import-in-extern-c",
+        # This warning would mean we had an error configuring the toolchain or modulemap
+        "-Werror=incomplete-umbrella",
     ],
 )
 


### PR DESCRIPTION
This would mean we accidentally messed up the toolchain / modulemap
generation
