### PR TITLE
Add -framework Foundation by default on macOS

### DIFF
--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -216,6 +216,7 @@ cc_args_list(
     name = "macos_toolchain_args",
     args = [
         "//toolchain/args/macos:macos_minimum_os_flags",
+        "//toolchain/args/macos:macos_default_framework_flags",
     ],
 )
 

--- a/toolchain/args/macos/BUILD.bazel
+++ b/toolchain/args/macos/BUILD.bazel
@@ -58,6 +58,16 @@ cc_args(
     }),
 )
 
+cc_args(
+    name = "macos_default_framework_flags",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = [
+        "-Wl,-framework,Foundation",
+    ],
+)
+
 # TODO(cerisier): Extract those into proper semantic args list.
 cc_args(
     name = "default_link_flags",


### PR DESCRIPTION
The apple_support toolchain, which is the default for building objc on
all apple platforms, adds this framework by default. Without this objc
likely doesn't link since it's expecting it. There are some other
default ones that are lower risk that we can add as needed. There's
really no downside since even binaries that don't link Foundation
directly will load it at runtime because libSystem transitively loads
it.
