### PR TITLE
Automatically add usr/lib/*.tbd on macOS

### DIFF
--- a/extensions/osx.bzl
+++ b/extensions/osx.bzl
@@ -18,7 +18,7 @@ def _osx_extension_impl(mctx):
     for module in mctx.modules:
         for frameworks_tag in module.tags.frameworks:
             frameworks.extend(frameworks_tag.names)
-        for _ in module.tags.experimental_include_all_sdk_libs:
+        if len(module.tags.experimental_include_all_sdk_libs) > 0:
             experimental_include_all_sdk_libs = True
 
     if not frameworks:
@@ -148,7 +148,7 @@ _frameworks_tag = tag_class(
 )
 
 _experimental_include_all_sdk_libs_tag = tag_class(
-    doc = "Include all usr/lib/*.tbd from the macOS SDK sysroot instead of only the minimal default set.",
+    doc = "Include most usr/lib/*.tbd from the macOS SDK sysroot instead of only the minimal default set. Some libraries that are symlinks to frameworks are still excluded.",
 )
 
 osx = module_extension(


### PR DESCRIPTION
The other tbd files can represent libraries that binaries need that
already exist on the system. This directory was previously ~1mb and with
this is ~3mbs. Alternatively we could allow users to specify libraries
to include as they can with frameworks, but this size differences makes
it seem like maybe it's ok to just include them all.

The only exception is libraries that point to frameworks, which produce
broken symlinks unless the framework is also included, and bazel fails
on that. For now I think we can just ignore those.

Some examples of ones that you might need are libxml2, and compression
