### PR TITLE
Fix issue with readonly remote exec file

### DIFF
--- a/3rd_party/libc/musl/musl.BUILD.bazel
+++ b/3rd_party/libc/musl/musl.BUILD.bazel
@@ -135,7 +135,7 @@ filegroup(
             "arch/{arch}/bits/syscall.h.in".format(arch = arch),
         ],
         outs = ["obj/{arch}/include/bits/syscall.h".format(arch = arch)],
-        cmd = "cp $1 $2 && sed -n -e 's/__NR_/SYS_/p' $1 >> $2",
+        cmd = "cat $1 > $2 && sed -n -e 's/__NR_/SYS_/p' $1 >> $2",
         args = [
             "$(location arch/{arch}/bits/syscall.h.in)".format(arch = arch),
             "$(location obj/{arch}/include/bits/syscall.h)".format(arch = arch),


### PR DESCRIPTION
Some remote exec providers are more strict about file permissions. This
action previously copied a readonly file, and then attempted to append
to it. That fails with buildbarn but not buildbuddy. We now create a new
file with the same contents instead, so that it doesn't inherit those
readonly permissions.
