### PR TITLE
Use stdlib-isystem for cxx stlib include path

### DIFF
--- a/toolchain/args/BUILD.bazel
+++ b/toolchain/args/BUILD.bazel
@@ -77,9 +77,9 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:objcpp_compile",
     ],
     args = [
-        "-isystem",
+        "-stdlib++-isystem",
         "{libcxx_headers_include_search_path}",
-        "-isystem",
+        "-stdlib++-isystem",
         "{libcxxabi_headers_include_search_path}",
     ],
     data = [

--- a/toolchain/args/linux/BUILD.bazel
+++ b/toolchain/args/linux/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_args_list")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -15,11 +16,15 @@ cc_args(
     ],
 )
 
+NON_CPP_ACTIONS = [
+    "@rules_cc//cc/toolchains/actions:c_compile_actions",
+    "@rules_cc//cc/toolchains/actions:assembly_actions",
+    "@rules_cc//cc/toolchains/actions:objc_compile",
+]
+
 cc_args(
-    name = "kernel_headers_include_search_paths",
-    actions = [
-        "@rules_cc//cc/toolchains/actions:source_compile_actions",
-    ],
+    name = "kernel_headers_include_search_paths_c",
+    actions = NON_CPP_ACTIONS,
     allowlist_include_directories = [
         "@kernel_headers//:kernel_headers_directory",
     ],
@@ -36,15 +41,43 @@ cc_args(
 )
 
 cc_args(
-    name = "glibc_headers_include_search_paths",
+    name = "kernel_headers_include_search_paths_cpp",
     actions = [
-        "@rules_cc//cc/toolchains/actions:source_compile_actions",
+        "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+    ],
+    allowlist_include_directories = [
+        "@kernel_headers//:kernel_headers_directory",
+    ],
+    args = [
+        "-stdlib++-isystem",
+        "{kernel_headers_include_search_path}",
+    ],
+    data = [
+        "@kernel_headers//:kernel_headers_directory",
+    ],
+    format = {
+        "kernel_headers_include_search_path": "@kernel_headers//:kernel_headers_directory",
+    },
+)
+
+cc_args_list(
+    name = "kernel_headers_include_search_paths",
+    args = [
+        ":kernel_headers_include_search_paths_c",
+        ":kernel_headers_include_search_paths_cpp",
+    ],
+)
+
+cc_args(
+    name = "glibc_headers_include_search_paths_c",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:c_compile_actions",
+        "@rules_cc//cc/toolchains/actions:assembly_actions",
     ],
     allowlist_include_directories = [
         "//runtimes/glibc:glibc_headers_include_search_directory",
     ],
     args = [
-        # "__GLIBC_MINOR__={d}", version.minor
         "-isystem",
         "{libc_headers_include_search_path}",
     ],
@@ -57,9 +90,38 @@ cc_args(
 )
 
 cc_args(
-    name = "sanitizer_headers_include_search_paths",
+    name = "glibc_headers_include_search_paths_cpp",
     actions = [
-        "@rules_cc//cc/toolchains/actions:source_compile_actions",
+        "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+    ],
+    allowlist_include_directories = [
+        "//runtimes/glibc:glibc_headers_include_search_directory",
+    ],
+    args = [
+        "-stdlib++-isystem",
+        "{libc_headers_include_search_path}",
+    ],
+    data = [
+        "//runtimes/glibc:glibc_headers_include_search_directory",
+    ],
+    format = {
+        "libc_headers_include_search_path": "//runtimes/glibc:glibc_headers_include_search_directory",
+    },
+)
+
+cc_args_list(
+    name = "glibc_headers_include_search_paths",
+    args = [
+        ":glibc_headers_include_search_paths_c",
+        ":glibc_headers_include_search_paths_cpp",
+    ],
+)
+
+cc_args(
+    name = "sanitizer_headers_include_search_paths_c",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:c_compile_actions",
+        "@rules_cc//cc/toolchains/actions:assembly_actions",
     ],
     allowlist_include_directories = [
         "//sanitizers:sanitizers_headers_include_search_directory",
@@ -74,6 +136,34 @@ cc_args(
     format = {
         "sanitizer_headers_include_search_paths": "//sanitizers:sanitizers_headers_include_search_directory",
     },
+)
+
+cc_args(
+    name = "sanitizer_headers_include_search_paths_cpp",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+    ],
+    allowlist_include_directories = [
+        "//sanitizers:sanitizers_headers_include_search_directory",
+    ],
+    args = [
+        "-stdlib++-isystem",
+        "{sanitizer_headers_include_search_paths}",
+    ],
+    data = [
+        "//sanitizers:sanitizers_headers_include_search_directory",
+    ],
+    format = {
+        "sanitizer_headers_include_search_paths": "//sanitizers:sanitizers_headers_include_search_directory",
+    },
+)
+
+cc_args_list(
+    name = "sanitizer_headers_include_search_paths",
+    args = [
+        ":sanitizer_headers_include_search_paths_c",
+        ":sanitizer_headers_include_search_paths_cpp",
+    ],
 )
 
 cc_args(


### PR DESCRIPTION
This change needs careful review due to its impact on correctness, long-term maintenance, and downstream users of the toolchain (e.g. rules_go, rules_foreign_cc).

### Background

Until now, we passed C++ include paths via `-isystem`. This worked because Clang implicitly appends its builtin headers at the end of the search path (and we also pass them explicitly via `-internal-isystem`).

In CUDA mode (`-x cuda`), the driver injects an additional builtin include path (`cuda_wrappers`) *before* the standard C++ includes. This ordering is required because these wrappers override parts of the C++ standard library specifically for CUDA.

With `-isystem`, we lose control over this ordering, which breaks CUDA compilation.

### The problem

We need to preserve Clang’s intended include ordering in CUDA mode:

```
<-isystem paths>
<clang/.../cuda_wrappers>
<-stdlib++-isystem paths>
<clang/.../include>
```

### Options considered

#### 1. Manually inject `cuda_wrappers`

This would restore the correct ordering, but requires reliably detecting CUDA mode.

That is non-trivial:
- A `cuda_compile` action is being introduced, but
- Many projects (e.g. XLA) compile `.cc` files with `-x cuda`, which bypasses extension-based detection

This is a good option but it means we can never be compliant with such codebases unless they rename their files to `.cu` or `.cu.cc`.

#### 2. Rely on the Clang driver (`-stdlib++-isystem`) **(chosen)**

`-stdlib++-isystem` lets the driver handle ordering of standard library includes correctly, including CUDA-specific adjustments.

However, this introduces a constraint:
- `-stdlib++-isystem` is ignored in C mode

### What this PR does

- In C++ (`cpp_compile`):
  - Pass all relevant include paths (`stdlib++`, `libc`, `kernel`) via `-stdlib++-isystem`
  - This ensures correct ordering relative to `cuda_wrappers`

- In C (`c_compile`):
  - Continue using `-isystem` for `libc` and `kernel`
  - Since `-stdlib++-isystem` is ignored

### Tradeoff

We are left with two imperfect options:

1. Detect CUDA and manually inject `cuda_wrappers`
   - Requires reliable CUDA mode detection → works but not in all cases.

2. Delegate ordering to the driver via `-stdlib++-isystem`
   - Correct behavior
   - But forces divergence between C and C++ include handling

This PR adopts option (2) as the only robust approach given current constraints.