### PR TITLE
Add support for 64 bits RISC-V targets

### DIFF
--- a/3rd_party/libc/glibc/glibc.BUILD.bazel
+++ b/3rd_party/libc/glibc/glibc.BUILD.bazel
@@ -84,6 +84,7 @@ cc_runtime_stage0_library(
     ] + select({
         "@platforms//cpu:x86_64": glibc_includes("x86_64"),
         "@platforms//cpu:aarch64": glibc_includes("aarch64"),
+        "@platforms//cpu:riscv64": glibc_includes("riscv64"),
     }),
     visibility = ["//visibility:public"],
 )
@@ -93,6 +94,7 @@ cc_runtime_stage0_library(
     srcs = select({
         "@platforms//cpu:x86_64": ["sysdeps/x86_64/start.S"],
         "@platforms//cpu:aarch64": ["sysdeps/aarch64/start.S"],
+        "@platforms//cpu:riscv64": ["sysdeps/riscv/start.S"],
     }, no_match_error = "Unsupported platform"),
     copts = [
         # Normally, we would pass -nostdinc, but since we pass -nostdlibinc
@@ -127,6 +129,7 @@ cc_runtime_stage0_library(
     includes = select({
         "@platforms//cpu:x86_64": glibc_includes("x86_64"),
         "@platforms//cpu:aarch64": glibc_includes("aarch64"),
+        "@platforms//cpu:riscv64": glibc_includes("riscv64"),
     }),
     implementation_deps = [
         ":kernel_headers",
@@ -226,6 +229,7 @@ cc_runtime_stage0_library(
     ] + select({
         "@platforms//cpu:x86_64": glibc_includes("x86_64"),
         "@platforms//cpu:aarch64": glibc_includes("aarch64"),
+        "@platforms//cpu:riscv64": glibc_includes("riscv64"),
     }),
     srcs = [
         # From stdlib/Makefile

--- a/3rd_party/libc/glibc/helpers.bzl
+++ b/3rd_party/libc/glibc/helpers.bzl
@@ -19,16 +19,12 @@ def glibc_includes(cpu):
 
     return [
         "include",
-
         "sysdeps/unix/sysv/linux/{}".format(cpu),
     ] + x86_64_variant + x86_parent + riscv64_variant + [
-
         "sysdeps/{}/nptl".format(cpu),
-
         "sysdeps/unix/sysv/linux/generic",
         "sysdeps/unix/sysv/linux/include",
         "sysdeps/unix/sysv/linux",
-
         "sysdeps/nptl",
         "sysdeps/pthread",
         "sysdeps/unix/sysv",

--- a/3rd_party/libc/glibc/helpers.bzl
+++ b/3rd_party/libc/glibc/helpers.bzl
@@ -1,4 +1,29 @@
 def glibc_includes(cpu):
+    if cpu == "riscv64":
+        return [
+            "include",
+            "sysdeps/unix/sysv/linux/riscv/rv64",
+            "sysdeps/unix/sysv/linux/riscv",
+            "sysdeps/unix/sysv/linux/wordsize-64",
+            "sysdeps/riscv/rv64/rvd",
+            "sysdeps/riscv/rv64/rvf",
+            "sysdeps/riscv/rv64",
+            "sysdeps/riscv/rvd",
+            "sysdeps/riscv/rvf",
+            "sysdeps/riscv/nptl",
+            "sysdeps/riscv",
+            "sysdeps/unix/sysv/linux/generic",
+            "sysdeps/unix/sysv/linux/include",
+            "sysdeps/unix/sysv/linux",
+            "sysdeps/nptl",
+            "sysdeps/pthread",
+            "sysdeps/unix/sysv",
+            "sysdeps/unix",
+            "sysdeps/wordsize-64",
+            "sysdeps/generic",
+            ".",
+        ]
+
     x86_64_variant = [
         "sysdeps/unix/sysv/linux/x86_64/64".format(cpu),
     ] if cpu == "x86_64" else []

--- a/3rd_party/libc/glibc/helpers.bzl
+++ b/3rd_party/libc/glibc/helpers.bzl
@@ -1,29 +1,5 @@
+# A good starting point for this is https://codeberg.org/ziglang/zig/src/branch/master/src/libs/glibc.zig add_include_dirs function
 def glibc_includes(cpu):
-    if cpu == "riscv64":
-        return [
-            "include",
-            "sysdeps/unix/sysv/linux/riscv/rv64",
-            "sysdeps/unix/sysv/linux/riscv",
-            "sysdeps/unix/sysv/linux/wordsize-64",
-            "sysdeps/riscv/rv64/rvd",
-            "sysdeps/riscv/rv64/rvf",
-            "sysdeps/riscv/rv64",
-            "sysdeps/riscv/rvd",
-            "sysdeps/riscv/rvf",
-            "sysdeps/riscv/nptl",
-            "sysdeps/riscv",
-            "sysdeps/unix/sysv/linux/generic",
-            "sysdeps/unix/sysv/linux/include",
-            "sysdeps/unix/sysv/linux",
-            "sysdeps/nptl",
-            "sysdeps/pthread",
-            "sysdeps/unix/sysv",
-            "sysdeps/unix",
-            "sysdeps/wordsize-64",
-            "sysdeps/generic",
-            ".",
-        ]
-
     x86_64_variant = [
         "sysdeps/unix/sysv/linux/x86_64/64".format(cpu),
     ] if cpu == "x86_64" else []
@@ -34,22 +10,32 @@ def glibc_includes(cpu):
         "sysdeps/x86",
     ] if cpu == "x86_64" else []
 
+    riscv64_variant = [
+        "sysdeps/unix/sysv/linux/riscv/rv64",
+    ] if cpu == "riscv64" else []
+
+    if cpu == "riscv64":
+        cpu = "riscv"
+
     return [
         "include",
+
         "sysdeps/unix/sysv/linux/{}".format(cpu),
-    ] + x86_64_variant + [
-        "sysdeps/{}".format(cpu),
-    ] + x86_parent + [
+    ] + x86_64_variant + x86_parent + riscv64_variant + [
+
+        "sysdeps/{}/nptl".format(cpu),
+
         "sysdeps/unix/sysv/linux/generic",
         "sysdeps/unix/sysv/linux/include",
         "sysdeps/unix/sysv/linux",
-        "sysdeps/{}/nptl".format(cpu),
+
         "sysdeps/nptl",
         "sysdeps/pthread",
         "sysdeps/unix/sysv",
         "sysdeps/unix/{}".format(cpu),
         "sysdeps/unix",
         "sysdeps/{}".format(cpu),
+        "sysdeps/wordsize-64",
         "sysdeps/generic",
         ".",
     ]

--- a/3rd_party/libc/musl/musl.BUILD.bazel
+++ b/3rd_party/libc/musl/musl.BUILD.bazel
@@ -2,7 +2,7 @@ load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@llvm//:sh_script.bzl", "sh_script")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
-MUSL_SUPPORTED_ARCHS = ["x86_64", "aarch64"]
+MUSL_SUPPORTED_ARCHS = ["x86_64", "aarch64", "riscv64"]
 
 filegroup(
     name = "compile_srcs",
@@ -80,6 +80,7 @@ alias(
     actual = select({
         "@platforms//cpu:x86_64": ":musl_internal_headers_x86_64",
         "@platforms//cpu:aarch64": ":musl_internal_headers_aarch64",
+        "@platforms//cpu:riscv64": ":musl_internal_headers_riscv64",
     }),
     visibility = ["//visibility:public"],
 )
@@ -225,6 +226,7 @@ alias(
     actual = select({
         "@platforms//cpu:x86_64": ":musl_libc_headers_x86_64",
         "@platforms//cpu:aarch64": ":musl_libc_headers_aarch64",
+        "@platforms//cpu:riscv64": ":musl_libc_headers_riscv64",
     }),
     visibility = ["//visibility:public"],
 )
@@ -234,6 +236,7 @@ alias(
     actual = select({
         "@platforms//cpu:x86_64": ":musl_libc_headers_x86_64_for_musl",
         "@platforms//cpu:aarch64": ":musl_libc_headers_aarch64_for_musl",
+        "@platforms//cpu:riscv64": ":musl_libc_headers_riscv64_for_musl",
     }),
     visibility = ["//visibility:public"],
 )
@@ -243,6 +246,7 @@ alias(
     actual = select({
         "@platforms//cpu:x86_64": ":headers_x86_64_include_directory",
         "@platforms//cpu:aarch64": ":headers_aarch64_include_directory",
+        "@platforms//cpu:riscv64": ":headers_riscv64_include_directory",
     }),
     visibility = ["//visibility:public"],
 )

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -292,6 +292,19 @@ filter_builtin_sources(
 )
 
 filter_builtin_sources(
+    name = "builtins_riscv64_sources",
+    srcs = [
+        ":builtins_generic_srcs",
+        ":builtins_generic_tf_sources",
+        "lib/builtins/cpu_model/riscv.c",
+        "lib/builtins/riscv/fp_mode.c",
+        "lib/builtins/riscv/save.S",
+        "lib/builtins/riscv/restore.S",
+        "lib/builtins/riscv/muldi3.S",
+    ],
+)
+
+filter_builtin_sources(
     name = "builtins_wasm32_sources",
     srcs = [
         ":builtins_generic_srcs",
@@ -331,6 +344,7 @@ cc_library(
     srcs = select({
         "@platforms//cpu:x86_64": [":builtins_x86_64_sources"],
         "@platforms//cpu:aarch64": [":builtins_aarch64_sources"],
+        "@platforms//cpu:riscv64": [":builtins_riscv64_sources"],
         "@platforms//cpu:wasm32": [":builtins_wasm32_sources"],
         "@platforms//cpu:wasm64": [":builtins_wasm64_sources"],
     }, no_match_error = """
@@ -361,6 +375,7 @@ cc_library(
             # - riscv32
             # - riscv64
             "@platforms//cpu:aarch64",
+            "@platforms//cpu:riscv64",
             "@platforms//cpu:x86_64",
         ): [
             ":builtins_bf16_sources",
@@ -402,6 +417,7 @@ cc_library(
             # - thumb
             # - thumbeb
             "@platforms//cpu:aarch64",
+            "@platforms//cpu:riscv64",
             "@platforms//cpu:x86_64",
         ): [
             "COMPILER_RT_HAS_FLOAT16",
@@ -422,6 +438,7 @@ cc_library(
         "lib/builtins/int_mulv_impl.inc",
         "lib/builtins/int_to_fp_impl.inc",
         "lib/builtins/cpu_model/cpu_model.h",
+        "lib/builtins/riscv/int_mul_impl.inc",
     ] + select({
         "@platforms//cpu:aarch64": [
             "lib/builtins/cpu_model/AArch64CPUFeatures.inc",
@@ -1971,6 +1988,9 @@ filegroup(
         ],
         "@platforms//cpu:aarch64": [
             "lib/tsan/rtl/tsan_rtl_aarch64.S",
+        ],
+        "@platforms//cpu:riscv64": [
+            "lib/tsan/rtl/tsan_rtl_riscv64.S",
         ],
         "//conditions:default": [],
     }),

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -438,13 +438,15 @@ cc_library(
         "lib/builtins/int_mulv_impl.inc",
         "lib/builtins/int_to_fp_impl.inc",
         "lib/builtins/cpu_model/cpu_model.h",
-        "lib/builtins/riscv/int_mul_impl.inc",
     ] + select({
         "@platforms//cpu:aarch64": [
             "lib/builtins/cpu_model/AArch64CPUFeatures.inc",
             "lib/builtins/cpu_model/aarch64/hwcap.inc",
             # "lib/builtins/cpu_model/aarch64/lse_atomics/atomic_helper.inc",
             "lib/builtins/cpu_model/aarch64/lse_atomics/getauxval.inc",
+        ],
+        "@platforms//cpu:riscv64": [
+            "lib/builtins/riscv/int_mul_impl.inc",
         ],
         "//conditions:default": [],
     }) + select({

--- a/3rd_party/llvm-project/x.x/compiler-rt/targets.bzl
+++ b/3rd_party/llvm-project/x.x/compiler-rt/targets.bzl
@@ -2,7 +2,7 @@
 Helper functions for defining targets.
 """
 
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 def atomic_helper_cc_library(name, pat, size, model):
@@ -15,7 +15,6 @@ def atomic_helper_cc_library(name, pat, size, model):
         name = unique_filename,
         src = "lib/builtins/aarch64/lse.S",
         out = "{}.S".format(unique_filename),
-        allow_symlink = True,
     )
 
     cc_library(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -98,6 +98,7 @@ llvm = use_extension("//extensions:llvm.bzl", "llvm")
 llvm.configure(
     targets = [
         "AArch64",
+        "RISCV",
         "X86",
         "WebAssembly",
         "NVPTX",

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ toolchain.exec(arch = "x86_64", os = "linux")
 toolchain.exec(arch = "aarch64", os = "linux")
 toolchain.target(arch = "x86_64", os = "linux")
 toolchain.target(arch = "aarch64", os = "linux")
+toolchain.target(arch = "riscv64", os = "linux")
 
 use_repo(toolchain, "llvm_toolchains")
 
@@ -93,8 +94,10 @@ Rust builds commonly require a few flags:
 | **x86_64-apple-darwin**  | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **aarch64-linux-gnu ¹**  | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **x86_64-linux-gnu ¹**   | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **riscv64-linux-gnu ¹**   | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **aarch64-linux-musl**   | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **x86_64-linux-musl**    | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **riscv64-linux-musl**    | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **aarch64-windows-gnu ²**| ✅ | ✅ | ✅ | ✅ | ✅ |
 | **x86_64-windows-gnu ²** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **wasm32-unknown-unknown** | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -136,6 +139,12 @@ Cross-compiling to macOS from any host is supported.
 
 By default, the official macOS SDK is downloaded from Apple CDN and used hermetically.
 We use a cross-platform reimplementation of `pkgutil` to unpack SDK packages, which works on all hosts.
+
+### RISC-V
+
+For now, RISC-V support is limited to Linux and currently hard-wired to the
+rv64gc ISA and lp64d ABI while we work out a clean way to configure freestanding
+targets and ISA matrices.
 
 ### Other platforms
 

--- a/constraints/libc/BUILD.bazel
+++ b/constraints/libc/BUILD.bazel
@@ -5,7 +5,7 @@ package(default_visibility = ["//visibility:public"])
 
 constraint_setting(
     name = "variant",
-    # For linux, this maps to a default gnu.2.28
+    # For linux, platform declarations may map this to an explicit default glibc.
     default_constraint_value = "unconstrained",
 )
 

--- a/constraints/libc/libc_versions.bzl
+++ b/constraints/libc/libc_versions.bzl
@@ -22,6 +22,15 @@ LIBCS = ["musl"] + GLIBCS
 
 DEFAULT_LIBC = "gnu.2.28"
 
+# compile-rt from LLVM requires kernel headers >= 5.10 for RISC-V.
+#
+# Because we don't have a good way to let the users choose the version of kernel headers,
+# we default on the hardcoded association we have with glibc versions.
+# glibc 2.33+ requires kernel headers 5.10+, so we default to it.
+#
+# This is a poor-man's solution for now
+#
+# TODO(cerisier): we should let users choose the kernel headers version
 DEFAULT_LIBCS = {
     ("linux", "riscv64"): "gnu.2.33",
 }

--- a/constraints/libc/libc_versions.bzl
+++ b/constraints/libc/libc_versions.bzl
@@ -21,3 +21,10 @@ GLIBCS = ["gnu.{}".format(glibc) for glibc in GLIBC_VERSIONS]
 LIBCS = ["musl"] + GLIBCS
 
 DEFAULT_LIBC = "gnu.2.28"
+
+DEFAULT_LIBCS = {
+    ("linux", "riscv64"): "gnu.2.33",
+}
+
+def default_libc(target_os, target_cpu):
+    return DEFAULT_LIBCS.get((target_os, target_cpu), DEFAULT_LIBC)

--- a/e2e/cross_compilation/BUILD.bazel
+++ b/e2e/cross_compilation/BUILD.bazel
@@ -48,6 +48,7 @@ cc_test(
 PLATFORMS = [
     "@llvm//platforms:linux_x86_64",
     "@llvm//platforms:linux_aarch64",
+    "@llvm//platforms:linux_riscv64",
     "@llvm//platforms:macos_x86_64",
     "@llvm//platforms:macos_aarch64",
     "@llvm//platforms:windows_amd64",

--- a/e2e/cross_compilation/BUILD.bazel
+++ b/e2e/cross_compilation/BUILD.bazel
@@ -59,6 +59,10 @@ PLATFORMS = [
 ] + [
     "@llvm//platforms:linux_aarch64_{}".format(libc)
     for libc in LIBCS
+] + [
+    # RISC-V needs special LIBC treatment because of the kernel-glibc association we do.
+    # Builtins requires kernel headers >= 5.10 which we hardcode to be 2.33+
+    "@llvm//platforms:linux_riscv64_musl",
 ]
 
 [

--- a/e2e/rules_rust/BUILD.bazel
+++ b/e2e/rules_rust/BUILD.bazel
@@ -13,6 +13,7 @@ rust_binary_cross_build_test_suite(
     platforms = {
         "@llvm//platforms:linux_x86_64": "x86-64",
         "@llvm//platforms:linux_aarch64": "aarch64",
+        "@llvm//platforms:linux_riscv64": "riscv64",
         "@llvm//platforms:windows_x86_64": "x86-64",
         "@llvm//platforms:windows_aarch64": "aarch64",
         # "@llvm//platforms:macos_x86_64": "x86-64",

--- a/e2e/rules_rust/MODULE.bazel
+++ b/e2e/rules_rust/MODULE.bazel
@@ -67,6 +67,7 @@ rust.toolchain(
         "x86_64-unknown-linux-musl",
         "x86_64-apple-darwin",
         "x86_64-pc-windows-gnullvm",
+        "riscv64-unknown-linux-gnu",
     ],
     versions = ["1.81.0"],
 )

--- a/e2e/rules_rust/MODULE.bazel
+++ b/e2e/rules_rust/MODULE.bazel
@@ -67,7 +67,7 @@ rust.toolchain(
         "x86_64-unknown-linux-musl",
         "x86_64-apple-darwin",
         "x86_64-pc-windows-gnullvm",
-        "riscv64-unknown-linux-gnu",
+        "riscv64gc-unknown-linux-gnu",
     ],
     versions = ["1.81.0"],
 )

--- a/extensions/toolchain.bzl
+++ b/extensions/toolchain.bzl
@@ -68,7 +68,7 @@ _platform_tag = tag_class(
         ),
         "arch": attr.string(
             mandatory = True,
-            values = ["x86_64", "aarch64"],
+            values = ["x86_64", "aarch64", "riscv64"],
         ),
     },
 )

--- a/kernel/extension/kernel_headers.bzl
+++ b/kernel/extension/kernel_headers.bzl
@@ -24,7 +24,7 @@ _SUPPORTED_ARCHS = [
     # "mips",
     # "openrisc",
     # "powerpc",
-    # "riscv",
+    "riscv",
     # "s390",
     # "sh",
     # "sparc",

--- a/kernel/extension/kernel_helpers.bzl
+++ b/kernel/extension/kernel_helpers.bzl
@@ -11,6 +11,8 @@ def arch_to_kernel_arch(arch):
         return "x86"
     elif arch == "aarch64":
         return "arm64"
+    elif arch == "riscv64":
+        return "riscv"
     elif arch == "armv7":
         return "arm"
     else:

--- a/platforms/common.bzl
+++ b/platforms/common.bzl
@@ -1,6 +1,7 @@
 ARCH_ALIASES = {
     "x86_64": ["amd64"],
     "aarch64": ["arm64"],
+    "riscv64": [],
 }
 
 SUPPORTED_TARGETS = [
@@ -8,6 +9,7 @@ SUPPORTED_TARGETS = [
     ("macos", "aarch64"),
     ("linux", "x86_64"),
     ("linux", "aarch64"),
+    ("linux", "riscv64"),
     ("windows", "x86_64"),
     ("windows", "aarch64"),
     ("none", "wasm32"),
@@ -26,4 +28,5 @@ SUPPORTED_EXECS = [
 LIBC_SUPPORTED_TARGETS = [
     ("linux", "x86_64"),
     ("linux", "aarch64"),
+    ("linux", "riscv64"),
 ]

--- a/platforms/declare_platforms.bzl
+++ b/platforms/declare_platforms.bzl
@@ -1,4 +1,4 @@
-load("//constraints/libc:libc_versions.bzl", "DEFAULT_LIBC", "LIBCS")
+load("//constraints/libc:libc_versions.bzl", "LIBCS", "default_libc")
 load("//platforms:common.bzl", "ARCH_ALIASES", "LIBC_SUPPORTED_TARGETS", "SUPPORTED_TARGETS")
 
 def declare_platforms():
@@ -17,7 +17,7 @@ def declare_platforms():
             #
             # Users can still create their own platforms without a libc
             # constraint if they want to.
-            constraints.append("//constraints/libc:{}".format(DEFAULT_LIBC))
+            constraints.append("//constraints/libc:{}".format(default_libc(target_os, target_cpu)))
 
         native.platform(
             name = "{}_{}".format(target_os, target_cpu),

--- a/runtimes/copy_to_resource_directory.bzl
+++ b/runtimes/copy_to_resource_directory.bzl
@@ -11,6 +11,7 @@ TRIPLE_SELECT_DICT = {
     "@llvm//platforms/config:linux_riscv64_gnu": "riscv64-unknown-linux-gnu",
     "@llvm//platforms/config:linux_x86_64_musl": "x86_64-unknown-linux-musl",
     "@llvm//platforms/config:linux_aarch64_musl": "aarch64-unknown-linux-musl",
+    "@llvm//platforms/config:linux_riscv64_musl": "riscv64-unknown-linux-musl",
     "@llvm//platforms/config:macos_x86_64": "darwin",
     "@llvm//platforms/config:macos_aarch64": "darwin",
     "@llvm//platforms/config:windows_x86_64": "x86_64-w64-windows-gnu",

--- a/runtimes/copy_to_resource_directory.bzl
+++ b/runtimes/copy_to_resource_directory.bzl
@@ -5,8 +5,10 @@ load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory_bin_action")
 TRIPLE_SELECT_DICT = {
     "@llvm//platforms/config:linux_x86_64": "x86_64-unknown-linux-gnu",
     "@llvm//platforms/config:linux_aarch64": "aarch64-unknown-linux-gnu",
+    "@llvm//platforms/config:linux_riscv64": "riscv64-unknown-linux-gnu",
     "@llvm//platforms/config:linux_x86_64_gnu": "x86_64-unknown-linux-gnu",
     "@llvm//platforms/config:linux_aarch64_gnu": "aarch64-unknown-linux-gnu",
+    "@llvm//platforms/config:linux_riscv64_gnu": "riscv64-unknown-linux-gnu",
     "@llvm//platforms/config:linux_x86_64_musl": "x86_64-unknown-linux-musl",
     "@llvm//platforms/config:linux_aarch64_musl": "aarch64-unknown-linux-musl",
     "@llvm//platforms/config:macos_x86_64": "darwin",

--- a/runtimes/glibc/BUILD.bazel
+++ b/runtimes/glibc/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//toolchain:selects.bzl", "platform_extra_binary")
 load(":glibc_linker_script.bzl", "make_glibc_linker_script")
@@ -40,19 +39,19 @@ glibc_stubs_assembly_files(
 
 # Make one target per lib assembly file
 [
-    select_file(
+    filegroup(
         name = "lib" + lib + ".s",
-        srcs = ":generate_glibc_stubs",
-        subpath = "glibc/build/" + lib + ".s",
+        srcs = [":generate_glibc_stubs"],
+        output_group = lib + "_s",
         visibility = ["//visibility:public"],
     )
     for lib in LIBC_SO_VERSIONS.keys()
 ]
 
-select_file(
+filegroup(
     name = "all.map",
-    srcs = ":generate_glibc_stubs",
-    subpath = "glibc/build/all.map",
+    srcs = [":generate_glibc_stubs"],
+    output_group = "all_map",
     visibility = ["//visibility:public"],
 )
 

--- a/runtimes/glibc/glibc_stubs_assembly_files.bzl
+++ b/runtimes/glibc/glibc_stubs_assembly_files.bzl
@@ -3,17 +3,17 @@ def _glibc_stubs_impl(ctx):
 
     version_script = ctx.actions.declare_file("build/all.map")
 
-    outputs = [
-        ctx.actions.declare_file("build/c.s"),
-        ctx.actions.declare_file("build/dl.s"),
-        ctx.actions.declare_file("build/ld.s"),
-        ctx.actions.declare_file("build/m.s"),
-        ctx.actions.declare_file("build/pthread.s"),
-        ctx.actions.declare_file("build/resolv.s"),
-        ctx.actions.declare_file("build/rt.s"),
-        ctx.actions.declare_file("build/util.s"),
-        version_script,
-    ]
+    assembly_outputs = {
+        "c": ctx.actions.declare_file("build/c.s"),
+        "dl": ctx.actions.declare_file("build/dl.s"),
+        "ld": ctx.actions.declare_file("build/ld.s"),
+        "m": ctx.actions.declare_file("build/m.s"),
+        "pthread": ctx.actions.declare_file("build/pthread.s"),
+        "resolv": ctx.actions.declare_file("build/resolv.s"),
+        "rt": ctx.actions.declare_file("build/rt.s"),
+        "util": ctx.actions.declare_file("build/util.s"),
+    }
+    outputs = list(assembly_outputs.values()) + [version_script]
 
     args = ctx.actions.args()
     args.add("-target")
@@ -28,8 +28,16 @@ def _glibc_stubs_impl(ctx):
         arguments = [args],
         outputs = outputs,
     )
+
+    output_groups = {
+        lib + "_s": depset([output])
+        for (lib, output) in assembly_outputs.items()
+    }
+    output_groups["all_map"] = depset([version_script])
+
     return [
         DefaultInfo(files = depset(outputs)),
+        OutputGroupInfo(**output_groups),
     ]
 
 glibc_stubs_assembly_files = rule(

--- a/runtimes/musl/BUILD.bazel
+++ b/runtimes/musl/BUILD.bazel
@@ -16,6 +16,7 @@ libc_musl_srcs_filegroup(
         {
             "@platforms//cpu:x86_64": "x86_64",
             "@platforms//cpu:aarch64": "aarch64",
+            "@platforms//cpu:riscv64": "riscv64",
         },
         no_match_error = "Unsupported platform",
     ),

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -274,8 +274,7 @@ cc_args_list(
     name = "toolchain_args",
     args = [
         # Common default compile flags.
-        "//toolchain/args:llvm_target_for_platform",
-        "//toolchain/args:target_arch_flags",
+        "//toolchain/args:target_flags",
         "//toolchain/args:no_absolute_paths_for_builtins",
         "//toolchain/args:deterministic_compile_flags",
         "//toolchain/args:module_map",

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -275,6 +275,7 @@ cc_args_list(
     args = [
         # Common default compile flags.
         "//toolchain/args:llvm_target_for_platform",
+        "//toolchain/args:target_arch_flags",
         "//toolchain/args:no_absolute_paths_for_builtins",
         "//toolchain/args:deterministic_compile_flags",
         "//toolchain/args:module_map",
@@ -299,6 +300,7 @@ cc_args_list(
 
         # Common default link flags.
         "//toolchain/args:fuse_ld",
+        "//toolchain/args:lto_plugin_target_flags",
         ":libcxx_library_search_paths",
         ":libunwind_library_search_paths",
         ":rtlib",

--- a/toolchain/args/BUILD.bazel
+++ b/toolchain/args/BUILD.bazel
@@ -44,6 +44,35 @@ cc_args(
 )
 
 cc_args(
+    name = "target_arch_flags",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = select({
+        "@platforms//cpu:riscv64": [
+            "-march=rv64gc",
+            "-mabi=lp64d",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+cc_args(
+    name = "lto_plugin_target_flags",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = select({
+        "@platforms//cpu:riscv64": [
+            "-Xlinker",
+            "-plugin-opt=-mattr=+m,+a,+f,+d,+c",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+cc_args(
     name = "module_map",
     actions = [
         "@rules_cc//cc/toolchains/actions:compile_actions",

--- a/toolchain/args/BUILD.bazel
+++ b/toolchain/args/BUILD.bazel
@@ -33,24 +33,19 @@ cc_args(
 )
 
 cc_args(
-    name = "llvm_target_for_platform",
+    name = "target_flags",
     actions = [
         "@rules_cc//cc/toolchains/actions:compile_actions",
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
     args = [
         "-target",
-    ] + LLVM_TARGET_TRIPLE,
-)
-
-cc_args(
-    name = "target_arch_flags",
-    actions = [
-        "@rules_cc//cc/toolchains/actions:compile_actions",
-        "@rules_cc//cc/toolchains/actions:link_actions",
-    ],
-    args = select({
+    ] + LLVM_TARGET_TRIPLE + select({
+        # We hardcode these for now given the complexity of RISC-V extensions.
+        # TODO(cerisier): Support ISA configuration.
         "@platforms//cpu:riscv64": [
+            # General-purpose 64-bit RISC-V.
+            # Common in most Linux distros.
             "-march=rv64gc",
             "-mabi=lp64d",
         ],
@@ -58,6 +53,11 @@ cc_args(
     }),
 )
 
+# See https://discourse.llvm.org/t/myterious-soft-float-output-in-lto-cache/70753/16
+# Target features are currently not passed to the LTO linker for RISC-V.
+# So we need to pass matching flags ourselves
+# NOTE: These neeed to be fully synchronized with the target_flags.
+# NOTE: partial linking (cc_stage0_object) maybe affected by https://github.com/llvm/llvm-project/issues/59350
 cc_args(
     name = "lto_plugin_target_flags",
     actions = [
@@ -66,7 +66,8 @@ cc_args(
     args = select({
         "@platforms//cpu:riscv64": [
             "-Xlinker",
-            "-plugin-opt=-mattr=+m,+a,+f,+d,+c",
+            # "-plugin-opt=-mattr=+m,+a,+f,+d,+c",
+            "-plugin-opt=-target-abi=lp64d",
         ],
         "//conditions:default": [],
     }),

--- a/toolchain/args/llvm_target_triple.bzl
+++ b/toolchain/args/llvm_target_triple.bzl
@@ -5,6 +5,7 @@ LLVM_TARGET_TRIPLE = select({
     "@llvm//platforms/config:linux_riscv64_gnu": ["riscv64-linux-gnu"],
     "@llvm//platforms/config:linux_x86_64_musl": ["x86_64-linux-musl"],
     "@llvm//platforms/config:linux_aarch64_musl": ["aarch64-linux-musl"],
+    "@llvm//platforms/config:linux_riscv64_musl": ["riscv64-linux-musl"],
     "@llvm//platforms/config:macos_x86_64": ["x86_64-apple-darwin"],
     "@llvm//platforms/config:macos_aarch64": ["aarch64-apple-darwin"],
     "@llvm//platforms/config:windows_x86_64": ["x86_64-w64-windows-gnu"],

--- a/toolchain/args/llvm_target_triple.bzl
+++ b/toolchain/args/llvm_target_triple.bzl
@@ -2,6 +2,7 @@ LLVM_TARGET_TRIPLE = select({
     #TODO: Generate this automatically
     "@llvm//platforms/config:linux_x86_64_gnu": ["x86_64-linux-gnu"],
     "@llvm//platforms/config:linux_aarch64_gnu": ["aarch64-linux-gnu"],
+    "@llvm//platforms/config:linux_riscv64_gnu": ["riscv64-linux-gnu"],
     "@llvm//platforms/config:linux_x86_64_musl": ["x86_64-linux-musl"],
     "@llvm//platforms/config:linux_aarch64_musl": ["aarch64-linux-musl"],
     "@llvm//platforms/config:macos_x86_64": ["x86_64-apple-darwin"],

--- a/toolchain/runtimes/BUILD.bazel
+++ b/toolchain/runtimes/BUILD.bazel
@@ -78,6 +78,7 @@ cc_args_list(
     args = [
         # Common default compile flags.
         "//toolchain/args:llvm_target_for_platform",
+        "//toolchain/args:target_arch_flags",
         "//toolchain/args:no_absolute_paths_for_builtins",
         "//toolchain/args:deterministic_compile_flags",
         "//toolchain/runtimes/args:optimization_flags",
@@ -101,6 +102,7 @@ cc_args_list(
 
         # Common default link flags.
         "//toolchain/args:fuse_ld",
+        "//toolchain/args:lto_plugin_target_flags",
         ":rtlib",
         ":resource_dir",
         ":default_link_flags",

--- a/toolchain/runtimes/BUILD.bazel
+++ b/toolchain/runtimes/BUILD.bazel
@@ -77,8 +77,7 @@ cc_args_list(
     name = "toolchain_args",
     args = [
         # Common default compile flags.
-        "//toolchain/args:llvm_target_for_platform",
-        "//toolchain/args:target_arch_flags",
+        "//toolchain/args:target_flags",
         "//toolchain/args:no_absolute_paths_for_builtins",
         "//toolchain/args:deterministic_compile_flags",
         "//toolchain/runtimes/args:optimization_flags",

--- a/toolchain/runtimes/cc_stage0_object.bzl
+++ b/toolchain/runtimes/cc_stage0_object.bzl
@@ -92,7 +92,7 @@ def _cc_stage0_object_impl(ctx):
         inputs = ctx.files.srcs,
         outputs = [ctx.outputs.out],
         arguments = [arguments],
-        tools = cc_toolchain._linker_files,
+        tools = cc_toolchain.all_files,
         executable = cc_tool,
         execution_requirements = {"supports-path-mapping": "1"},
         mnemonic = "CcStage0Compile",

--- a/toolchain/runtimes/cc_stage0_object.bzl
+++ b/toolchain/runtimes/cc_stage0_object.bzl
@@ -92,7 +92,7 @@ def _cc_stage0_object_impl(ctx):
         inputs = ctx.files.srcs,
         outputs = [ctx.outputs.out],
         arguments = [arguments],
-        tools = cc_toolchain.all_files,
+        tools = cc_toolchain._linker_files,
         executable = cc_tool,
         execution_requirements = {"supports-path-mapping": "1"},
         mnemonic = "CcStage0Compile",

--- a/toolchain/runtimes/cc_unsanitized_library.bzl
+++ b/toolchain/runtimes/cc_unsanitized_library.bzl
@@ -29,9 +29,6 @@ def _reset_sanitizers_impl(_settings, _attr):
         # we are compiling sanitizers, so we want all runtimes except sanitizers.
         # TODO(cerisier): Should this be exressed with a dedicated stage ?
         "//toolchain:runtime_stage": "complete",
-
-        # We want to build those binaries using the prebuilt compiler toolchain
-        "//toolchain:source": "prebuilt",
     }
 
 _reset_sanitizers = transition(
@@ -61,7 +58,6 @@ _reset_sanitizers = transition(
         "//config:host_asan",
         "//config:host_lsan",
         "//toolchain:runtime_stage",
-        "//toolchain:source",
     ],
 )
 

--- a/toolchain/runtimes/with_cfg_runtimes_common.bzl
+++ b/toolchain/runtimes/with_cfg_runtimes_common.bzl
@@ -16,12 +16,6 @@ def configure_builder_for_runtimes(builder, runtime_stage, linkmode = "static", 
         runtime_stage,
     )
 
-    # TODO(cerisier): Why constraint here ?
-    builder.set(
-        Label("//toolchain:source"),
-        "prebuilt",
-    )
-
     builder.set(
         Label("//runtimes:linkmode"),
         linkmode,


### PR DESCRIPTION
Contributes to #29 

This PR is ready for review now that prebuilts support RISC-V target since #433.

For now, this only brings support for generic linux riscv64 baseline: `rv64gc` and `lp64d`.
The custom `-plugin-opt` is a dirty fix to https://discourse.llvm.org/t/myterious-soft-float-output-in-lto-cache/70753/17

I wired basic gnu and musl test for rules_rust and cross_compaliation e2e.