### PR TITLE
Patch zlib-ng build to add to system include path.

### DIFF
--- a/3rd_party/llvm-project/21.x/patches/zlib-angle-include.patch
+++ b/3rd_party/llvm-project/21.x/patches/zlib-angle-include.patch
@@ -1,0 +1,16 @@
+diff --git a/utils/bazel/third_party_build/zlib-ng.BUILD b/utils/bazel/third_party_build/zlib-ng.BUILD
+index bb880c0e3279..6f1c6ad6aef0 100644
+--- a/utils/bazel/third_party_build/zlib-ng.BUILD
++++ b/utils/bazel/third_party_build/zlib-ng.BUILD
+@@ -91,8 +91,9 @@ cc_library(
+         ],
+         "//conditions:default": [],
+     }),
+-    # Clang includes zlib with angled instead of quoted includes, so we need
+-    # strip_include_prefix here.
++    # LLVM consumes zlib via angle includes, so export the repo root as a
++    # normal include directory in addition to rewriting the include prefix.
++    includes = ["."],
+     strip_include_prefix = ".",
+     visibility = ["//visibility:public"],
+ )

--- a/3rd_party/llvm-project/22.x/patches/zlib-angle-include.patch
+++ b/3rd_party/llvm-project/22.x/patches/zlib-angle-include.patch
@@ -1,0 +1,16 @@
+diff --git a/utils/bazel/third_party_build/zlib-ng.BUILD b/utils/bazel/third_party_build/zlib-ng.BUILD
+index d97d7e65f7f8..6f1c6ad6aef0 100644
+--- a/utils/bazel/third_party_build/zlib-ng.BUILD
++++ b/utils/bazel/third_party_build/zlib-ng.BUILD
+@@ -91,8 +91,9 @@ cc_library(
+         ],
+         "//conditions:default": [],
+     }),
+-    # Clang includes zlib with angled instead of quoted includes, so we need
+-    # strip_include_prefix here.
++    # LLVM consumes zlib via angle includes, so export the repo root as a
++    # normal include directory in addition to rewriting the include prefix.
++    includes = ["."],
+     strip_include_prefix = ".",
+     visibility = ["//visibility:public"],
+ )

--- a/extensions/llvm_source.bzl
+++ b/extensions/llvm_source.bzl
@@ -30,6 +30,7 @@ _LLVM_21_SOURCE_PATCHES = _DEFAULT_SOURCE_PATCHES + [
     "//3rd_party/llvm-project/21.x/patches:llvm-overlay-starlark.patch",
     "//3rd_party/llvm-project/21.x/patches:llvm-windows-stack-size.patch",
     "//3rd_party/llvm-project/21.x/patches:libcxx-lgamma_r.patch",
+    "//3rd_party/llvm-project/21.x/patches:zlib-angle-include.patch",
 ]
 
 _LLVM_22_SOURCE_PATCHES = _DEFAULT_SOURCE_PATCHES + [
@@ -40,6 +41,7 @@ _LLVM_22_SOURCE_PATCHES = _DEFAULT_SOURCE_PATCHES + [
     "//3rd_party/llvm-project/22.x/patches:no_rules_python.patch",
     "//3rd_party/llvm-project/22.x/patches:llvm-windows-stack-size.patch",
     "//3rd_party/llvm-project/22.x/patches:libcxx-lgamma_r.patch",
+    "//3rd_party/llvm-project/22.x/patches:zlib-angle-include.patch",
 ]
 
 _LLVM_PATCHES_BY_MAJOR = {


### PR DESCRIPTION
Zlib is included with angle brackets in e.g. CRC.cpp so we need to put the zlib directory on the system include path for it to be used downstream. Otherwise things like libFuzzer fail to build.

TBH I'm not 100% sure this is the correct fix for this but there doesn't seem to be any other way to get LLVM compiling against the included zlib-ng.