### PR TITLE
Make module map selection target-aware.

### DIFF
--- a/toolchain/declare_toolchains.bzl
+++ b/toolchain/declare_toolchains.bzl
@@ -10,21 +10,21 @@ def declare_toolchains(*, execs = SUPPORTED_EXECS, targets = SUPPORTED_TARGETS):
         targets: List of (os, arch) tuples describing target platforms.
     """
     for (exec_os, exec_cpu) in execs:
-        cc_toolchain_name = "{}_{}_cc_toolchain".format(exec_os, exec_cpu)
-
-        # Even though `tool_map` has an exec transition, Bazel doesn't properly handle
-        # binding a single `cc_toolchain` to multiple toolchains with different `exec_compatible_with`.
-        # See https://github.com/bazelbuild/rules_cc/issues/299#issuecomment-2660340534
-        cc_toolchain(
-            name = cc_toolchain_name,
-            tool_map = platform_cc_tool_map(exec_os, exec_cpu),
-            module_map = platform_module_map(exec_os, exec_cpu),
-            extra_args = [
-                resource_dir_arg(exec_os, exec_cpu),
-            ],
-        )
-
         for (target_os, target_cpu) in targets:
+            cc_toolchain_name = "{}_{}_to_{}_{}_cc_toolchain".format(exec_os, exec_cpu, target_os, target_cpu)
+
+            # Even though `tool_map` has an exec transition, Bazel doesn't properly handle
+            # binding a single `cc_toolchain` to multiple toolchains with different `exec_compatible_with`.
+            # See https://github.com/bazelbuild/rules_cc/issues/299#issuecomment-2660340534
+            cc_toolchain(
+                name = cc_toolchain_name,
+                tool_map = platform_cc_tool_map(exec_os, exec_cpu),
+                module_map = platform_module_map(exec_os, exec_cpu, target_os, target_cpu),
+                extra_args = [
+                    resource_dir_arg(exec_os, exec_cpu),
+                ],
+            )
+
             native.toolchain(
                 name = "{}_{}_to_{}_{}".format(exec_os, exec_cpu, target_os, target_cpu),
                 exec_compatible_with = [
@@ -42,3 +42,12 @@ def declare_toolchains(*, execs = SUPPORTED_EXECS, targets = SUPPORTED_TARGETS):
                 toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
                 visibility = ["//visibility:public"],
             )
+
+        # Alias {exec_os}_{exec_cpu}_cc_toolchain to the "cross compilation"
+        # toolchain {exec_os}_{exec_cpu}_to_{exec_os}_{exec_cpu}_cc_toolchain to
+        # maintain backwards compatibility.
+        native.alias(
+            name = "{}_{}_cc_toolchain".format(exec_os, exec_cpu),
+            actual = ":{}_{}_to_{}_{}_cc_toolchain".format(exec_os, exec_cpu, exec_os, exec_cpu),
+            visibility = ["//visibility:public"],
+        )

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -3,8 +3,14 @@ load("@llvm//runtimes:module_map.bzl", "include_path", "module_map")
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
 load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
+load("//constraints/libc:libc_versions.bzl", "LIBCS")
 load("//:directory.bzl", "headers_directory")
+load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
+load("//toolchain:module_map_names.bzl", "module_map_target_name")
 load("//toolchain:selects.bzl", "platform_extra_binary")
+
+def _linux_target_headers_name(target_cpu, libc):
+    return "linux_target_headers_{}_{}".format(target_cpu, libc.replace(".", "_"))
 
 def declare_llvm_targets(*, suffix = ""):
     headers_directory(
@@ -187,23 +193,18 @@ def declare_llvm_targets(*, suffix = ""):
     )
 
     # This must match //toolchain:linux_toolchain_args
-    include_path(
-        name = "linux_target_headers",
-        srcs = [
-            ":builtin_resource_dir",
-            "@llvm//runtimes/libcxx:libcxx_headers_include_search_directory",
-            "@llvm//runtimes/libcxx:libcxxabi_headers_include_search_directory",
-            "@kernel_headers//:kernel_headers_directory",
-            "@llvm//sanitizers:sanitizers_headers_include_search_directory",
-        ] + select({
-            "@llvm//platforms/config:musl": [
-                "@llvm//runtimes/musl:musl_headers_include_search_directory",
-            ],
-            "@llvm//platforms/config:gnu": [
-                "@llvm//runtimes/glibc:glibc_headers_include_search_directory",
-            ],
-        }),
-    )
+    for (_, target_cpu) in LIBC_SUPPORTED_TARGETS:
+        for libc in LIBCS + ["unconstrained"]:
+            include_path(
+                name = _linux_target_headers_name(target_cpu, libc),
+                srcs = [
+                    ":builtin_resource_dir",
+                    "@llvm//runtimes/libcxx:libcxx_headers_include_search_directory",
+                    "@llvm//runtimes/libcxx:libcxxabi_headers_include_search_directory",
+                    "@kernel_headers//:kernel_headers_directory",
+                    "@llvm//sanitizers:sanitizers_headers_include_search_directory",
+                ] + (["@llvm//runtimes/musl:musl_headers_include_search_directory"] if libc == "musl" else ["@llvm//runtimes/glibc:glibc_headers_include_search_directory"]),
+            )
 
     # this must match //toolchain:windows_toolchain_args
     include_path(
@@ -231,9 +232,16 @@ def declare_llvm_targets(*, suffix = ""):
         name = "module_map",
         include_path = select({
             "@platforms//os:macos": ":macos_target_headers",
-            "@platforms//os:linux": ":linux_target_headers",
             "@platforms//os:windows": ":windows_target_headers",
             "@platforms//os:none": ":wasm_target_headers",
         }),
         visibility = ["//visibility:public"],
     )
+
+    for (target_os, target_cpu) in LIBC_SUPPORTED_TARGETS:
+        for libc in LIBCS + ["unconstrained"]:
+            module_map(
+                name = module_map_target_name(target_os, target_cpu, libc),
+                include_path = ":" + _linux_target_headers_name(target_cpu, libc),
+                visibility = ["//visibility:public"],
+            )

--- a/toolchain/module_map_names.bzl
+++ b/toolchain/module_map_names.bzl
@@ -1,0 +1,5 @@
+def module_map_target_name(target_os, target_cpu, libc = None):
+    name = "module_map_{}_{}".format(target_os, target_cpu)
+    if libc != None:
+        name += "_" + libc.replace(".", "_")
+    return name

--- a/toolchain/selects.bzl
+++ b/toolchain/selects.bzl
@@ -1,3 +1,6 @@
+load("//constraints/libc:libc_versions.bzl", "LIBCS")
+load("//toolchain:module_map_names.bzl", "module_map_target_name")
+
 LLVM_VERSION = "22.1.3"
 
 def platform_llvm_binary(binary):
@@ -27,8 +30,16 @@ def _tool_repo(exec_os, exec_cpu):
     cpu_part = "amd64" if exec_cpu == "x86_64" else "arm64"
     return "@llvm-toolchain-minimal-%s-%s-%s//" % (LLVM_VERSION, os_part, cpu_part)
 
-def platform_module_map(exec_os, exec_cpu):
-    return _tool_repo(exec_os, exec_cpu) + ":module_map"
+def platform_module_map(exec_os, exec_cpu, target_os, target_cpu):
+    tool_repo = _tool_repo(exec_os, exec_cpu)
+
+    if target_os == "linux":
+        return select({
+            "@llvm//platforms/config:{}_{}_{}".format(target_os, target_cpu, libc): tool_repo + ":" + module_map_target_name(target_os, target_cpu, libc)
+            for libc in LIBCS + ["unconstrained"]
+        })
+
+    return tool_repo + ":module_map"
 
 def resource_dir_arg(exec_os, exec_cpu):
     return _tool_repo(exec_os, exec_cpu) + ":compile_resource_dir"


### PR DESCRIPTION
Before the cc_toolchain module_map depended only on the execution platform so something like this:

`bazel build //some:target`

followed by:

`bazel build --platforms=@llvm//platforms:linux_arm64_gnu.2.28 //third_party:smoke`

Would fail because it would try to use the x86 module map for ARM.

To fix it, we make platform_module_map depend on the target as well.

CC toolchains are now always named:
   {exec_os}_{exec_cpu}_to_{target_os}_{target_cpu}_cc_toolchain

To prevent existing client breakage, we alias the old names to the new "cross-compiler" toolchain:
   {exec_os}_{exec_cpu}_to_{exec_os}_{exec_cpu}_cc_toolchain

Then we can define a module map and linux target headers target for each combination of target cpu and libc configuration. This is only for linux targets, other targets remain the same.