### PR TITLE
Add no_legacy_features to toolchains

### DIFF
--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -154,6 +154,73 @@ cc_feature(
     feature_name = "parse_headers",
 )
 
+cc_feature(
+    name = "coverage_stub",
+    overrides = "@rules_cc//cc/toolchains/features/legacy:coverage",
+)
+
+cc_feature(
+    name = "llvm_coverage_map_format",
+    args = [
+        ":llvm_coverage_map_format_compile_args",
+        ":llvm_coverage_map_format_link_args",
+    ],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:llvm_coverage_map_format",
+    requires_any_of = [":coverage_stub"],
+)
+
+cc_args(
+    name = "llvm_coverage_map_format_compile_args",
+    actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+    args = [
+        "-fprofile-instr-generate",
+        "-fcoverage-mapping",
+    ],
+)
+
+cc_args(
+    name = "llvm_coverage_map_format_link_args",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = ["-fprofile-instr-generate"],
+)
+
+cc_feature(
+    name = "gcc_coverage_map_format",
+    args = [
+        ":gcc_coverage_map_format_compile_args",
+        ":gcc_coverage_map_format_link_args",
+    ],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:gcc_coverage_map_format",
+    requires_any_of = [":coverage_stub"],
+)
+
+cc_args(
+    name = "gcc_coverage_map_format_compile_args",
+    actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+    args = [
+        "-fprofile-arcs",
+        "-ftest-coverage",
+    ],
+)
+
+cc_args(
+    name = "gcc_coverage_map_format_link_args",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = ["--coverage"],
+)
+
+cc_feature(
+    name = "fully_static_link",
+    args = [":fully_static_link_args"],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:fully_static_link",
+)
+
+cc_args(
+    name = "fully_static_link_args",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = ["-static"],
+)
+
 ###
 
 cc_feature_set(
@@ -165,6 +232,10 @@ cc_feature_set(
         ":dbg_stub",
         ":static_link_cpp_runtimes",
         ":parse_headers",
+        ":coverage_stub",
+        ":llvm_coverage_map_format",
+        ":gcc_coverage_map_format",
+        ":fully_static_link",
     ],
     visibility = ["//visibility:public"],
 )

--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -154,6 +154,7 @@ cc_feature(
     feature_name = "parse_headers",
 )
 
+# TODO: Remove after https://github.com/bazelbuild/rules_cc/pull/385
 cc_feature(
     name = "coverage_stub",
     overrides = "@rules_cc//cc/toolchains/features/legacy:coverage",

--- a/toolchain/features/legacy/BUILD.bazel
+++ b/toolchain/features/legacy/BUILD.bazel
@@ -51,12 +51,9 @@ cc_feature(
     visibility = ["//visibility:public"],
 )
 
-# Define a no-op static_libgcc feature so rules_cc does not backfill its
-# legacy default `-static-libgcc` flag when static_link_cpp_runtimes is enabled.
 cc_feature(
-    name = "static_libgcc",
-    overrides = "@rules_cc//cc/toolchains/features/legacy:static_libgcc",
-    visibility = ["//visibility:public"],
+    name = "no_legacy_features",
+    feature_name = "no_legacy_features",
 )
 
 ###
@@ -65,7 +62,6 @@ cc_feature_set(
     name = "all_legacy_builtin_features",
     all_of = [
         ":default_compile_flags",
-        ":static_libgcc",
     ] + select({
         "@platforms//os:windows": [],
         "//conditions:default": [
@@ -80,7 +76,7 @@ cc_feature_set(
 cc_feature_set(
     name = "experimental_replace_legacy_action_config_features",
     all_of = [
-        ":backfill_legacy_args",
+        ":no_legacy_features",
         "@rules_cc//cc/toolchains/args/archiver_flags:feature",
         "@rules_cc//cc/toolchains/args/pic_flags:feature",
         "@rules_cc//cc/toolchains/args/libraries_to_link:feature",
@@ -141,17 +137,4 @@ cc_args(
     args = ["-Wl,-soname,{runtime_solib_name}"],
     format = {"runtime_solib_name": "@rules_cc//cc/toolchains/variables:runtime_solib_name"},
     requires_not_none = "@rules_cc//cc/toolchains/variables:runtime_solib_name",
-)
-
-# Taken from
-# https://github.com/bazelbuild/rules_cc/blob/541eda5d72e9b5f18e6a24e8d14975afcd865717/cc/toolchains/args/BUILD#L44-L53
-cc_feature(
-    name = "backfill_legacy_args",
-    feature_name = "experimental_replace_legacy_action_config_features",
-    # TODO: Convert remaining items in this list into their actual args.
-    implies = [
-        "@rules_cc//cc/toolchains/features/legacy:build_interface_libraries",
-        "@rules_cc//cc/toolchains/features/legacy:dynamic_library_linker_tool",
-    ],
-    visibility = ["//visibility:private"],
 )


### PR DESCRIPTION
By default rules_cc adds a lot of features if you don't define them, and
you don't set `no_legacy_features`. At this point the features in
rules_cc for rules based toolchains, as well as the ones in this repo,
cover everything we need. This makes sure we don't get surprising
behavior from those defaults.
