### PR TITLE
osx: pass -lSystem before builtins.a

### DIFF
--- a/toolchain/args/macos/BUILD.bazel
+++ b/toolchain/args/macos/BUILD.bazel
@@ -92,8 +92,8 @@ cc_args(
     ],
     # -l: is not supported by lld64
     args = [
-        "{libclang_rt.builtins.a}",
         "-lSystem",
+        "{libclang_rt.builtins.a}",
     ],
     data = [
         "//runtimes/compiler-rt:clang_rt.builtins.static",


### PR DESCRIPTION
This is cope but matches a bit better flags ordering of vanilla clang invocations which passes builtins after -lSystem

This is because -lSystem also provides its own symbols provided by compiler_rt dylib.

A second improvement would be to pass default libs "after" object files and static libraries from compile units.