### PR TITLE
Set minimum bazel version to 8.5.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "llvm",
     version = "0.0.0",
-    bazel_compatibility = [">=8.3.0"],
+    bazel_compatibility = [">=8.5.0"],
     compatibility_level = 0,
 )
 


### PR DESCRIPTION
To avoid https://github.com/hermeticbuild/hermetic-llvm/pull/437
