### PR TITLE
Fix source archive name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       bazel_test_command: true
       prerelease: false
       release_files: |
-        toolchains_llvm_bootstrapped-*.tar.gz
+        hermetic-llvm-*.tar.gz
       tag_name: ${{ inputs.tag_name || github.ref_name }}
   publish:
     # Skip BCR publish for prebuilts tags like llvm-* or prebuilts-extras-*.

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -9,8 +9,8 @@ VERSION=${TAG:1}
 # The prefix is chosen to match what GitHub generates for source archives
 # This guarantees that users can easily switch from a released artifact to a source archive
 # with minimal differences in their code (e.g. strip_prefix remains the same)
-PREFIX="toolchains_llvm_bootstrapped-$VERSION"
-ARCHIVE="toolchains_llvm_bootstrapped-$TAG.tar.gz"
+PREFIX="hermetic-llvm-$VERSION"
+ARCHIVE="hermetic-llvm-$TAG.tar.gz"
 
 # NB: configuration for 'git archive' is in /.gitattributes
 git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE


### PR DESCRIPTION
It's automatic based on the repo name