### PR TITLE
Remove use of config=ruleset

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,7 +6,7 @@ try-import %workspace%/../../internal_tools/preset.bazelrc
 # Don’t want to push a rules author to update their deps if not needed.
 # https://bazel.build/reference/command-line-reference#flag--check_direct_dependencies
 # https://bazelbuild.slack.com/archives/C014RARENH0/p1691158021917459?thread_ts=1691156601.420349&cid=C014RARENH0
-common --config=ruleset
+common --check_direct_dependencies=off
 
 common --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 common --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1


### PR DESCRIPTION
We don't have this bazelrc in the BCR CI job
