### PR TITLE
Move sanitizer search paths after project includes

### DIFF
--- a/toolchain/args/linux/BUILD.bazel
+++ b/toolchain/args/linux/BUILD.bazel
@@ -66,8 +66,12 @@ cc_args(
     allowlist_include_directories = [
         "//sanitizers:sanitizers_headers_include_search_directory",
     ],
+    # Make sure these sanitizer paths come after any user supplied paths, which
+    # might also include another version of llvm's sanitizer headers.
     args = [
-        "-isystem",
+        "-Xclang",
+        "-internal-isystem",
+        "-Xclang",
         "{sanitizer_headers_include_search_paths}",
     ],
     data = [


### PR DESCRIPTION
Until bazel 9.x `includes` on `cc_library` also uses `-isystem`. When
building llvm-project itself in its own repo with this toolchain, this
toolchain's compilerrt header search paths would come before the in-tree
paths.
