### PR TITLE
Optimize CopyFile actions for compiler-rt

### DIFF
--- a/3rd_party/llvm-project/x.x/compiler-rt/targets.bzl
+++ b/3rd_party/llvm-project/x.x/compiler-rt/targets.bzl
@@ -15,6 +15,7 @@ def atomic_helper_cc_library(name, pat, size, model):
         name = unique_filename,
         src = "lib/builtins/aarch64/lse.S",
         out = "{}.S".format(unique_filename),
+        allow_symlink = True,
     )
 
     cc_library(

--- a/3rd_party/llvm-project/x.x/libcxx/libcxx.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libcxx/libcxx.BUILD.bazel
@@ -118,6 +118,7 @@ copy_file(
     name = "__assertion_handler",
     src = "vendor/llvm/default_assertion_handler.in",
     out = "include/__assertion_handler",
+    allow_symlink = True,
 )
 
 copy_to_directory(


### PR DESCRIPTION
This saves 250 RPCs, we can just do a single syscall to symlink :)