### PR TITLE
Remove some linker flags from windows

### DIFF
--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -32,6 +32,7 @@ cc_args(
             #TODO: should be on a config that match ld64 specifically
             "-Wl,-dead_strip",
         ],
+        "@platforms//os:windows": [],
         "//conditions:default": [
             #TODO: should be somehow done only if the choosen linker supports it
             "-Wl,--gc-sections",
@@ -50,6 +51,7 @@ cc_args(
         "//config:lsan_enabled": [],
         "@platforms//cpu:wasm32": [],
         "@platforms//cpu:wasm64": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["-Wl,--icf=safe"],
     }),
 )


### PR DESCRIPTION
I noticed these are both invalid for lld-link.exe in the warnings in https://github.com/hermeticbuild/hermetic-llvm/issues/474
