### PR TITLE
Use zig macOS sysroot by default

### DIFF
--- a/3rd_party/llvm-project/x.x/libcxx/libcxx.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libcxx/libcxx.BUILD.bazel
@@ -347,6 +347,7 @@ cc_library(
     ]) + [
         "@libcxxabi//:textual_hdrs",
     ],
+    visibility = ["@llvm//runtimes/libcxx:__pkg__"],
 )
 
 cc_runtime_stage0_static_library(

--- a/3rd_party/llvm-project/x.x/libcxxabi/libcxxabi.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libcxxabi/libcxxabi.BUILD.bazel
@@ -154,6 +154,7 @@ cc_library(
         "src/**/*.h",
         "src/**/*.def",
     ]),
+    visibility = ["@llvm//runtimes/libcxx:__pkg__"],
 )
 
 cc_runtime_stage0_static_library(

--- a/3rd_party/macos_sdk/CLTools_macOSNMOS_SDK.BUILD.bazel
+++ b/3rd_party/macos_sdk/CLTools_macOSNMOS_SDK.BUILD.bazel
@@ -8,6 +8,44 @@ headers_directory(
     path = ".",
 )
 
+filegroup(
+    name = "libcxx_headers_include_search_directory",
+    srcs = [],
+)
+
+filegroup(
+    name = "libcxxabi_headers_include_search_directory",
+    srcs = [],
+)
+
+filegroup(
+    name = "static_runtime_lib",
+    srcs = [],
+)
+
+filegroup(
+    name = "dynamic_runtime_lib",
+    srcs = [],
+)
+
+cc_args(
+    name = "libcxx_headers_include_search_paths",
+    actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+    args = [],
+)
+
+cc_args(
+    name = "libcxx_library_search_paths",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = [],
+)
+
+cc_args(
+    name = "libcxx_runtime_link_flags",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = [],
+)
+
 cc_args(
     name = "sysroot_flags",
     actions = [

--- a/3rd_party/macos_sdk/ZigLibc.BUILD.bazel
+++ b/3rd_party/macos_sdk/ZigLibc.BUILD.bazel
@@ -26,25 +26,33 @@ cc_args(
 cc_args(
     name = "darwin_headers_include_search_paths",
     actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
-    args = [],
+    allowlist_include_directories = [":sysroot"],
+    args = [
+        "-Xclang",
+        "-internal-isystem",
+        "-Xclang",
+        "{sysroot}/include/any-darwin-any",
+    ],
+    data = [":sysroot"],
+    format = {"sysroot": ":sysroot"},
 )
 
 cc_args(
     name = "darwin_library_search_paths",
     actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = [],
+    args = ["-L{sysroot}/darwin"],
+    data = [":sysroot"],
+    format = {"sysroot": ":sysroot"},
 )
 
 cc_args(
     name = "default_framework_flags",
     actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = [
-        "-Wl,-framework,Foundation",
-    ],
+    args = [],
 )
 
 cc_args(
     name = "stdlib_flags",
     actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = [],
+    args = ["-nostdlib++"],
 )

--- a/3rd_party/macos_sdk/ZigLibc.BUILD.bazel
+++ b/3rd_party/macos_sdk/ZigLibc.BUILD.bazel
@@ -8,6 +8,36 @@ headers_directory(
     path = ".",
 )
 
+alias(
+    name = "libcxx_headers_include_search_directory",
+    actual = "@llvm//runtimes/libcxx:libcxx_headers_include_search_directory",
+)
+
+alias(
+    name = "libcxxabi_headers_include_search_directory",
+    actual = "@llvm//runtimes/libcxx:libcxxabi_headers_include_search_directory",
+)
+
+alias(
+    name = "libcxx_headers_include_search_paths",
+    actual = "@llvm//toolchain/args:libcxx_headers_include_search_paths",
+)
+
+alias(
+    name = "libcxx_library_search_paths",
+    actual = "@llvm//toolchain/args:libcxx_library_search_paths",
+)
+
+filegroup(
+    name = "static_runtime_lib",
+    srcs = [],
+)
+
+filegroup(
+    name = "dynamic_runtime_lib",
+    srcs = [],
+)
+
 cc_args(
     name = "sysroot_flags",
     actions = [
@@ -40,9 +70,26 @@ cc_args(
 cc_args(
     name = "darwin_library_search_paths",
     actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = ["-L{sysroot}/darwin"],
+    args = ["-L{sysroot}/darwin/."],
     data = [":sysroot"],
     format = {"sysroot": ":sysroot"},
+)
+
+cc_args(
+    name = "libcxx_runtime_link_flags",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = [
+        "{libcxx}",
+        "{libcxxabi}",
+    ],
+    data = [
+        "@llvm//runtimes/libcxx:libcxx.stage0",
+        "@llvm//runtimes/libcxx:libcxxabi.stage0",
+    ],
+    format = {
+        "libcxx": "@llvm//runtimes/libcxx:libcxx.stage0",
+        "libcxxabi": "@llvm//runtimes/libcxx:libcxxabi.stage0",
+    },
 )
 
 cc_args(

--- a/3rd_party/macos_sdk/ZigLibc.BUILD.bazel
+++ b/3rd_party/macos_sdk/ZigLibc.BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@llvm//:directory.bzl", "headers_directory")
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 
@@ -38,6 +40,40 @@ filegroup(
     srcs = [],
 )
 
+run_binary(
+    name = "c",
+    outs = ["libc.a"],
+    args = [
+        "rc",
+        "$@",
+    ] + select({
+        "@platforms//os:macos": ["--format=darwin"],
+        "//conditions:default": ["--format=gnu"],
+    }),
+    tool = "@llvm//tools:llvm-ar",
+)
+
+run_binary(
+    name = "m",
+    outs = ["libm.a"],
+    args = [
+        "rc",
+        "$@",
+    ] + select({
+        "@platforms//os:macos": ["--format=darwin"],
+        "//conditions:default": ["--format=gnu"],
+    }),
+    tool = "@llvm//tools:llvm-ar",
+)
+
+copy_to_directory(
+    name = "darwin_stub_library_search_directory",
+    srcs = [
+        ":c",
+        ":m",
+    ],
+)
+
 cc_args(
     name = "sysroot_flags",
     actions = [
@@ -70,9 +106,18 @@ cc_args(
 cc_args(
     name = "darwin_library_search_paths",
     actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = ["-L{sysroot}/darwin/."],
-    data = [":sysroot"],
-    format = {"sysroot": ":sysroot"},
+    args = [
+        "-L{sysroot}/darwin/.",
+        "-L{darwin_stub_library_search_directory}",
+    ],
+    data = [
+        ":darwin_stub_library_search_directory",
+        ":sysroot",
+    ],
+    format = {
+        "darwin_stub_library_search_directory": ":darwin_stub_library_search_directory",
+        "sysroot": ":sysroot",
+    },
 )
 
 cc_args(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -114,14 +114,6 @@ mingw = use_extension("//runtimes/mingw/extension:mingw.bzl", "mingw")
 use_repo(mingw, "mingw")
 
 osx = use_extension("//extensions:osx.bzl", "osx")
-osx.from_archive(
-    sha256 = "edc7ce9b8f09e0c7a39aaa714f941b4c2597f333ec1ffe59a14d67eb36cdb7e7",
-    strip_prefix = "Payload/Library/Developer/CommandLineTools/SDKs/MacOSX26.4.sdk",
-    type = "pkg",
-    urls = [
-        "https://swcdn.apple.com/content/downloads/60/13/122-35686-A_30JUXWIJFR/ck0gzuw5qccefzm3ptlwou3pu6a55d0o02/CLTools_macOSNMOS_SDK.pkg",
-    ],
-)
 use_repo(osx, "macos_sdk")
 
 glibc = use_extension("//runtimes/glibc/extension:glibc.bzl", "glibc")

--- a/README.md
+++ b/README.md
@@ -137,8 +137,11 @@ MSVCRT-based MinGW and native MSVC targets are not yet supported.
 
 Cross-compiling to macOS from any host is supported.
 
-By default, the official macOS SDK is downloaded from Apple CDN and used hermetically.
-We use a cross-platform reimplementation of `pkgutil` to unpack SDK packages, which works on all hosts.
+By default, Zig's macOS sysroot is used. If macOS SDK frameworks or
+additional SDK libraries are requested, the toolchain falls back to
+downloading the official macOS SDK from Apple CDN. We use a
+cross-platform reimplementation of `pkgutil` to unpack SDK packages,
+which works on all hosts.
 
 ### RISC-V
 

--- a/extensions/osx.bzl
+++ b/extensions/osx.bzl
@@ -12,6 +12,43 @@ _DEFAULT_FRAMEWORKS = [
     "SystemConfiguration",
 ]
 
+_DEFAULT_ZIG_LIBC_ARCHIVE = struct(
+    sha256 = "553334a7d6453baaa3cdaace52c1cd1044f415c35355569bc8a7408cf295a1bc",
+    strip_prefix = "zig/lib/libc",
+    type = "tar.gz",
+    urls = [
+        "https://codeberg.org/ziglang/zig/archive/5cc281e7232b9f1bc5f4d732e4a37fb5df02f780.tar.gz",
+    ],
+)
+
+_DEFAULT_APPLE_SDK_ARCHIVE = struct(
+    sha256 = "edc7ce9b8f09e0c7a39aaa714f941b4c2597f333ec1ffe59a14d67eb36cdb7e7",
+    strip_prefix = "Payload/Library/Developer/CommandLineTools/SDKs/MacOSX26.4.sdk",
+    type = "pkg",
+    urls = [
+        "https://swcdn.apple.com/content/downloads/60/13/122-35686-A_30JUXWIJFR/ck0gzuw5qccefzm3ptlwou3pu6a55d0o02/CLTools_macOSNMOS_SDK.pkg",
+    ],
+)
+
+def _declare_zig_libc_sdk(from_archive):
+    http_bsdtar_archive(
+        name = "macos_sdk",
+        add_prefix = "sysroot",
+        files = {
+            "sysroot/BUILD.bazel": "//3rd_party/macos_sdk:ZigLibc.BUILD.bazel",
+        },
+        includes = [
+            "darwin",
+            "darwin/*",
+            "include/any-darwin-any",
+            "include/any-darwin-any/*",
+        ],
+        sha256 = from_archive.sha256,
+        strip_prefix = from_archive.strip_prefix,
+        type = from_archive.type,
+        urls = from_archive.urls,
+    )
+
 def _get_from_archive(mctx):
     module_selected_archive = None
 
@@ -28,27 +65,9 @@ def _get_from_archive(mctx):
 
         module_selected_archive = module_archives[0]
 
-    if module_selected_archive != None:
-        return module_selected_archive
+    return module_selected_archive
 
-    fail("Missing osx.from_archive(...): set osx.from_archive(urls = [...], sha256 = ..., strip_prefix = ..., type = ...) in your MODULE.bazel")
-
-def _osx_extension_impl(mctx):
-    frameworks = []
-    experimental_include_all_sdk_libs = False
-    from_archive = _get_from_archive(mctx)
-
-    for module in mctx.modules:
-        for frameworks_tag in module.tags.frameworks:
-            frameworks.extend(frameworks_tag.names)
-        if len(module.tags.experimental_include_all_sdk_libs) > 0:
-            experimental_include_all_sdk_libs = True
-
-    experimental_include_all_sdk_libs = mctx.getenv("BAZEL_MACOS_EXPERIMENTAL_INCLUDE_ALL_SDK_LIBS") == "1"
-    frameworks_env = mctx.getenv("BAZEL_MACOS_FRAMEWORKS")
-    if frameworks_env:
-        frameworks = [f.strip() for f in frameworks_env.split(",") if f.strip()]
-
+def _declare_apple_sdk(from_archive, frameworks, experimental_include_all_sdk_libs):
     if not frameworks:
         frameworks = _DEFAULT_FRAMEWORKS
 
@@ -172,6 +191,32 @@ def _osx_extension_impl(mctx):
             type = from_archive.type,
             **archive_kwargs
         )
+
+def _osx_extension_impl(mctx):
+    frameworks = []
+    experimental_include_all_sdk_libs = False
+    from_archive = _get_from_archive(mctx)
+
+    for module in mctx.modules:
+        for frameworks_tag in module.tags.frameworks:
+            frameworks.extend(frameworks_tag.names)
+        if len(module.tags.experimental_include_all_sdk_libs) > 0:
+            experimental_include_all_sdk_libs = True
+
+    experimental_include_all_sdk_libs = experimental_include_all_sdk_libs or mctx.getenv("BAZEL_MACOS_EXPERIMENTAL_INCLUDE_ALL_SDK_LIBS") == "1"
+    frameworks_env = mctx.getenv("BAZEL_MACOS_FRAMEWORKS")
+    if frameworks_env:
+        frameworks = [f.strip() for f in frameworks_env.split(",") if f.strip()]
+
+    use_apple_sdk = from_archive or frameworks or experimental_include_all_sdk_libs
+    if use_apple_sdk:
+        _declare_apple_sdk(
+            from_archive = from_archive or _DEFAULT_APPLE_SDK_ARCHIVE,
+            frameworks = frameworks,
+            experimental_include_all_sdk_libs = experimental_include_all_sdk_libs,
+        )
+    else:
+        _declare_zig_libc_sdk(_DEFAULT_ZIG_LIBC_ARCHIVE)
 
     metadata_kwargs = {}
     if bazel_features.external_deps.extension_metadata_has_reproducible:

--- a/runtimes/libcxx/BUILD.bazel
+++ b/runtimes/libcxx/BUILD.bazel
@@ -1,10 +1,21 @@
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("//runtimes:defs.bzl", "stub_library")
+load("//toolchain/runtimes:filegroup.bzl", "stage0_filegroup")
+
+alias(
+    name = "libcxx",
+    actual = "@libcxx//:libcxx",
+)
 
 alias(
     name = "libcxx.static",
     actual = "@libcxx//:libcxx.static",
     visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libcxxabi",
+    actual = "@libcxxabi//:libcxxabi",
 )
 
 alias(
@@ -22,6 +33,18 @@ alias(
 alias(
     name = "libcxxabi.shared",
     actual = "@libcxxabi//:libcxxabi.shared",
+    visibility = ["//visibility:public"],
+)
+
+stage0_filegroup(
+    name = "libcxx.stage0",
+    srcs = [":libcxx"],
+    visibility = ["//visibility:public"],
+)
+
+stage0_filegroup(
+    name = "libcxxabi.stage0",
+    srcs = [":libcxxabi"],
     visibility = ["//visibility:public"],
 )
 

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -166,7 +166,9 @@ cc_args_list(
     name = "sysroot_flags",
     args = select({
         "@platforms//os:macos": [
-            "//toolchain/args/macos:macos_sdk_sysroot",
+            "@macos_sdk//sysroot:sysroot_flags",
+            "@macos_sdk//sysroot:darwin_headers_include_search_paths",
+            "@macos_sdk//sysroot:darwin_library_search_paths",
         ],
         "//conditions:default": [
             "//toolchain/args:empty_sysroot_flags",
@@ -187,7 +189,9 @@ cc_args_list(
 cc_args_list(
     name = "stdlib",
     args = select({
-        "@platforms//os:macos": [],
+        "@platforms//os:macos": [
+            "@macos_sdk//sysroot:stdlib_flags",
+        ],
         "//conditions:default": [
             "//toolchain/args:stdlib",
         ],
@@ -216,7 +220,7 @@ cc_args_list(
     name = "macos_toolchain_args",
     args = [
         "//toolchain/args/macos:macos_minimum_os_flags",
-        "//toolchain/args/macos:macos_default_framework_flags",
+        "@macos_sdk//sysroot:default_framework_flags",
     ],
 )
 

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -132,13 +132,34 @@ cc_args_list(
 cc_args_list(
     name = "libcxx_library_search_paths",
     args = select({
-        # libc++ is provided by the macOS SDK.
-        "@platforms//os:macos": [],
+        "@platforms//os:macos": [
+            "@macos_sdk//sysroot:libcxx_library_search_paths",
+        ],
         "@platforms//os:linux": [
             "//toolchain/args:libcxx_library_search_paths",
         ],
         "@platforms//os:windows": [
             "//toolchain/args:libcxx_library_search_paths",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+cc_args_list(
+    name = "libcxx_headers_include_search_paths",
+    args = select({
+        "@platforms//os:macos": [
+            "@macos_sdk//sysroot:libcxx_headers_include_search_paths",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+cc_args_list(
+    name = "libcxx_runtime_link_flags",
+    args = select({
+        "@platforms//os:macos": [
+            "@macos_sdk//sysroot:libcxx_runtime_link_flags",
         ],
         "//conditions:default": [],
     }),
@@ -282,6 +303,7 @@ cc_args_list(
         "//toolchain/args:no_absolute_paths_for_builtins",
         "//toolchain/args:deterministic_compile_flags",
         "//toolchain/args:module_map",
+        ":libcxx_headers_include_search_paths",
         ":sysroot_flags",
         ":hermetic_compile_flags",
 
@@ -305,6 +327,7 @@ cc_args_list(
         "//toolchain/args:fuse_ld",
         "//toolchain/args:lto_plugin_target_flags",
         ":libcxx_library_search_paths",
+        ":libcxx_runtime_link_flags",
         ":libunwind_library_search_paths",
         ":rtlib",
         ":stdlib",

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -183,6 +183,8 @@ def declare_llvm_targets(*, suffix = ""):
         srcs = [
             ":builtin_resource_dir",
             "@macos_sdk//sysroot",
+            "@macos_sdk//sysroot:libcxx_headers_include_search_directory",
+            "@macos_sdk//sysroot:libcxxabi_headers_include_search_directory",
         ],
     )
 

--- a/toolchain/runtimes/BUILD.bazel
+++ b/toolchain/runtimes/BUILD.bazel
@@ -163,6 +163,16 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "filegroup",
+    srcs = ["filegroup.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@llvm//toolchain/runtimes:with_cfg_runtimes_common",
+        "@with_cfg.bzl//:with_cfg",
+    ],
+)
+
 # TODO: Depends on private API that isn't visible
 # bzl_library(
 #     name = "cc_unsanitized_library",

--- a/toolchain/runtimes/filegroup.bzl
+++ b/toolchain/runtimes/filegroup.bzl
@@ -1,0 +1,8 @@
+load("@llvm//toolchain/runtimes:with_cfg_runtimes_common.bzl", "configure_builder_for_runtimes")
+load("@with_cfg.bzl", "with_cfg")
+
+_builder = with_cfg(
+    native.filegroup,
+)
+
+stage0_filegroup, _stage0_filegroup_internal = configure_builder_for_runtimes(_builder, "stage0").build()


### PR DESCRIPTION
This avoids downloading from the unstable dmg url for the simplest cases
that don't require real frameworks or extra libraries.
