### PR TITLE
Disable static library validator tool on bazel8

### DIFF
--- a/e2e/rules_cc/MODULE.bazel
+++ b/e2e/rules_cc/MODULE.bazel
@@ -11,9 +11,6 @@ local_path_override(
     path = "../../",
 )
 
-bazel_features = use_extension("@bazel_features//private:extensions.bzl", "version_extension")
-use_repo(bazel_features, "bazel_features_globals", "bazel_features_version")
-
 llvm_source = use_extension("@llvm//extensions:llvm_source.bzl", "llvm_source")
 use_repo(llvm_source, "compiler-rt", "libcxx", "libcxxabi", "libunwind", "llvm-libc", "llvm-raw", "llvm_config", "llvm_zlib", "llvm_zstd", "openmp")
 

--- a/e2e/rules_cc/bazel_version.bzl
+++ b/e2e/rules_cc/bazel_version.bzl
@@ -1,12 +1,9 @@
-load("@bazel_features_version//:version.bzl", "version")
+load("@bazel_features//:features.bzl", "bazel_features")
 
 def validate_static_library_compatible():
-    if not version:
-        return []
-    if int(version.split(".", 1)[0]) >= 9:
+    if bazel_features.cc.supports_starlarkified_toolchains:
         return []
 
-    # Bazel 8 drops `cc_args(env = ...)` on the validate_static_library action.
-    # Keep this validator integration coverage on Bazel 9+, where the tool env
-    # is propagated correctly.
+    # Bazel 8 drops `cc_args(env = ...)` on validate_static_library. Keep this
+    # validator integration coverage on Bazel 9+, where the tool env is propagated.
     return ["@platforms//:incompatible"]

--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -1,3 +1,4 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@llvm_config//:version.bzl", "LLVM_VERSION_MAJOR")
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
@@ -5,6 +6,14 @@ load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
 load("//platforms:common.bzl", "SUPPORTED_TARGETS")
 load("//toolchain:cc_toolchain.bzl", "cc_toolchain")
 load(":bootstrap_binary.bzl", "bootstrap_binary", "bootstrap_directory")
+
+def _validate_static_library_tool(prefix):
+    if not bazel_features.cc.supports_starlarkified_toolchains:
+        return {}
+
+    return {
+        "@rules_cc//cc/toolchains/actions:validate_static_library": prefix + "/static-library-validator",
+    }
 
 def declare_tool_map(exec_os, exec_cpu):
     prefix = exec_os + "_" + exec_cpu
@@ -19,8 +28,7 @@ def declare_tool_map(exec_os, exec_cpu):
         "@rules_cc//cc/toolchains/actions:link_actions": prefix + "/lld",
         "@rules_cc//cc/toolchains/actions:objcopy_embed_data": prefix + "/llvm-objcopy",
         "@rules_cc//cc/toolchains/actions:strip": prefix + "/llvm-strip",
-        "@rules_cc//cc/toolchains/actions:validate_static_library": prefix + "/static-library-validator",
-    }
+    } | _validate_static_library_tool(prefix)
 
     cc_tool_map(
         name = prefix + "/default_tools",

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -1,9 +1,14 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@llvm//runtimes:module_map.bzl", "include_path", "module_map")
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
 load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
 load("//:directory.bzl", "headers_directory")
 load("//toolchain:selects.bzl", "platform_extra_binary", "platform_extra_binary_files")
+
+_VALIDATE_STATIC_LIBRARY_TOOL = {
+    "@rules_cc//cc/toolchains/actions:validate_static_library": ":static_library_validator",
+} if bazel_features.cc.supports_starlarkified_toolchains else {}
 
 def declare_llvm_targets(*, suffix = ""):
     headers_directory(
@@ -123,8 +128,7 @@ def declare_llvm_targets(*, suffix = ""):
         "@rules_cc//cc/toolchains/actions:objcopy_embed_data": ":llvm-objcopy",
         "@rules_cc//cc/toolchains/actions:dwp": ":llvm-dwp",
         "@rules_cc//cc/toolchains/actions:strip": ":llvm-strip",
-        "@rules_cc//cc/toolchains/actions:validate_static_library": ":static_library_validator",
-    }
+    } | _VALIDATE_STATIC_LIBRARY_TOOL
 
     cc_tool_map(
         name = "default_tools",


### PR DESCRIPTION
`env` is only passed in rules_cc starlark version :( 