### PR TITLE
Bump bazel constraints down

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "llvm",
     version = "0.0.0",
-    bazel_compatibility = [">=8.5.0"],
+    bazel_compatibility = [">=7.7.0"],
 )
 
 bazel_dep(name = "bazel_lib", version = "3.2.2")

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Add this to your `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "llvm", version = "0.6.0")
+bazel_dep(name = "llvm", version = "0.7.3")
 
 register_toolchains("@llvm//toolchain:all")
 ```
@@ -28,6 +28,8 @@ register_toolchains("@llvm//toolchain:all")
 See https://github.com/hermeticbuild/hermetic-llvm/releases/latest
 
 This registers all toolchains declared by this module for all supported targets.
+
+This module sets bazel_compatibility to 7.7+ so it can be imported for constraints, but it is highly recommended to use Bazel 8.5+ for full functionality.
 
 ## Description
 


### PR DESCRIPTION
so downstream users like rules_rs transitives that only need the constraints can use it.