### PR TITLE
Revert bootstrap transition unification

### DIFF
--- a/toolchain/bootstrap/BUILD.bazel
+++ b/toolchain/bootstrap/BUILD.bazel
@@ -1,11 +1,11 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("//tools:defs.bzl", "TOOLCHAIN_BINARIES")
-load(":bootstrap_binary.bzl", "bootstrap_binary")
+load(":bootstrap_binary.bzl", "exec_bootstrap_binary")
 
 # bootstrap toolchains are declared top level
 
 [
-    bootstrap_binary(
+    exec_bootstrap_binary(
         name = tool,
         actual = "@llvm-project//llvm",
         visibility = ["//visibility:public"],

--- a/toolchain/bootstrap/bootstrap_binary.bzl
+++ b/toolchain/bootstrap/bootstrap_binary.bzl
@@ -32,8 +32,10 @@ _LLVM_TOOLS = [
     "sancov",
 ]
 
-def _bootstrap_transition_impl(_settings, _attr):
+def _bootstrap_transition_impl(_settings, attr):
     return {
+        "//command_line_option:platforms": str(attr.platform),
+
         # we don't want to pass sanitizers up the compiler toolchain for now
         "//config:ubsan": False,
         "//config:cfi": False,
@@ -70,6 +72,7 @@ bootstrap_transition = transition(
     implementation = _bootstrap_transition_impl,
     inputs = [],
     outputs = [
+        "//command_line_option:platforms",
         "//config:ubsan",
         "//config:cfi",
         "//config:msan",
@@ -129,6 +132,95 @@ bootstrap_binary = rule(
             allow_single_file = True,
             mandatory = True,
         ),
+        "platform": attr.label(
+            mandatory = True,
+        ),
+        "symlink": attr.bool(
+            default = True,
+            doc = "If set to False, will copy the tool instead of symlinking",
+        ),
+    },
+    toolchains = COPY_FILE_TOOLCHAINS,
+)
+
+# TODO(zbarsky): This should replace bootstrap_binary once rules_cc is fixed.
+def _exec_bootstrap_transition_impl(_settings, _attr):
+    return {
+        "//config:ubsan": False,
+        "//config:cfi": False,
+        "//config:msan": False,
+        "//config:dfsan": False,
+        "//config:nsan": False,
+        "//config:safestack": False,
+        "//config:rtsan": False,
+        "//config:tysan": False,
+        "//config:tsan": False,
+        "//config:asan": False,
+        "//config:lsan": False,
+        "//config:host_ubsan": False,
+        "//config:host_cfi": False,
+        "//config:host_msan": False,
+        "//config:host_dfsan": False,
+        "//config:host_nsan": False,
+        "//config:host_safestack": False,
+        "//config:host_rtsan": False,
+        "//config:host_tysan": False,
+        "//config:host_tsan": False,
+        "//config:host_asan": False,
+        "//config:host_lsan": False,
+
+        # we are compiling final programs, so we want all runtimes.
+        "//toolchain:runtime_stage": "complete",
+
+        # We want to build those binaries using the prebuilt compiler toolchain
+        "//toolchain:source": "prebuilt",
+
+        # Enable the same set of tools we provide with prebuilts.
+        "@llvm-project//llvm:driver-tools": _LLVM_TOOLS,
+    }
+
+exec_bootstrap_transition = transition(
+    implementation = _exec_bootstrap_transition_impl,
+    inputs = [],
+    outputs = [
+        "//config:ubsan",
+        "//config:cfi",
+        "//config:msan",
+        "//config:dfsan",
+        "//config:nsan",
+        "//config:safestack",
+        "//config:rtsan",
+        "//config:tysan",
+        "//config:tsan",
+        "//config:asan",
+        "//config:lsan",
+        "//config:host_ubsan",
+        "//config:host_cfi",
+        "//config:host_msan",
+        "//config:host_dfsan",
+        "//config:host_nsan",
+        "//config:host_safestack",
+        "//config:host_rtsan",
+        "//config:host_tysan",
+        "//config:host_tsan",
+        "//config:host_asan",
+        "//config:host_lsan",
+        "//toolchain:runtime_stage",
+        "//toolchain:source",
+        "@llvm-project//llvm:driver-tools",
+    ],
+)
+
+# TODO(zbarsky): This should replace bootstrap_binary once rules_cc is fixed.
+exec_bootstrap_binary = rule(
+    implementation = _bootstrap_binary_impl,
+    executable = True,
+    attrs = {
+        "actual": attr.label(
+            cfg = exec_bootstrap_transition,
+            allow_single_file = True,
+            mandatory = True,
+        ),
         "symlink": attr.bool(
             default = True,
             doc = "If set to False, will copy the tool instead of symlinking",
@@ -159,6 +251,9 @@ bootstrap_directory = rule(
     attrs = {
         "srcs": attr.label(
             cfg = bootstrap_transition,
+            mandatory = True,
+        ),
+        "platform": attr.label(
             mandatory = True,
         ),
         "strip_prefix": attr.string(mandatory = True),

--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -18,6 +18,14 @@ def _validate_static_library_tool(prefix):
 def declare_tool_map(exec_os, exec_cpu):
     prefix = exec_os + "_" + exec_cpu
 
+    native.platform(
+        name = prefix + "_platform",
+        constraint_values = [
+            "@platforms//cpu:{}".format(exec_cpu),
+            "@platforms//os:{}".format(exec_os),
+        ],
+    )
+
     COMMON_TOOLS = {
         "@rules_cc//cc/toolchains/actions:assembly_actions": prefix + "/clang",
         "@rules_cc//cc/toolchains/actions:c_compile": prefix + "/clang",
@@ -46,12 +54,15 @@ def declare_tool_map(exec_os, exec_cpu):
 
     bootstrap_binary(
         name = prefix + "/bin/clang",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
     bootstrap_directory(
         name = prefix + "/clang_builtin_headers_include_directory",
         srcs = "@llvm-project//clang:builtin_headers_files",
+        # TODO(zbarsky): Probably shouldn't force platform here.
+        platform = prefix + "_platform",
         destination = prefix + "/lib/clang/{}/include".format(LLVM_VERSION_MAJOR),
         strip_prefix = "clang/lib/Headers",
     )
@@ -67,6 +78,7 @@ def declare_tool_map(exec_os, exec_cpu):
 
     bootstrap_binary(
         name = prefix + "/bin/clang++",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
         # Copy instead of symlink so clang's InstalledDir matches the packaged tree.
         # This is crucial for properly locating the various linkers, since we don't use `-ld-path`.
@@ -84,6 +96,7 @@ def declare_tool_map(exec_os, exec_cpu):
 
     bootstrap_binary(
         name = prefix + "/bin/header-parser",
+        platform = prefix + "_platform",
         actual = "@llvm//tools/internal:header-parser",
     )
 
@@ -114,16 +127,19 @@ def declare_tool_map(exec_os, exec_cpu):
 
     bootstrap_binary(
         name = prefix + "/bin/static-library-validator",
+        platform = prefix + "_platform",
         actual = "@llvm//tools/internal:static-library-validator",
     )
 
     bootstrap_binary(
         name = prefix + "/bin/llvm-nm",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
     bootstrap_binary(
         name = prefix + "/bin/c++filt",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
@@ -157,21 +173,25 @@ def declare_tool_map(exec_os, exec_cpu):
 
     bootstrap_binary(
         name = prefix + "/bin/ld.lld",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
     bootstrap_binary(
         name = prefix + "/bin/ld64.lld",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
     bootstrap_binary(
         name = prefix + "/bin/lld",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
     bootstrap_binary(
         name = prefix + "/bin/wasm-ld",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
@@ -188,6 +208,7 @@ def declare_tool_map(exec_os, exec_cpu):
 
     bootstrap_binary(
         name = prefix + "/bin/llvm-ar",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
@@ -198,6 +219,7 @@ def declare_tool_map(exec_os, exec_cpu):
 
     bootstrap_binary(
         name = prefix + "/bin/llvm-libtool-darwin",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
@@ -208,6 +230,7 @@ def declare_tool_map(exec_os, exec_cpu):
 
     bootstrap_binary(
         name = prefix + "/bin/llvm-dwp",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
@@ -218,6 +241,7 @@ def declare_tool_map(exec_os, exec_cpu):
 
     bootstrap_binary(
         name = prefix + "/bin/llvm-objcopy",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
@@ -228,6 +252,7 @@ def declare_tool_map(exec_os, exec_cpu):
 
     bootstrap_binary(
         name = prefix + "/bin/llvm-strip",
+        platform = prefix + "_platform",
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 


### PR DESCRIPTION
This reverts 4bb0041c1435fe05720578e9564e0fba7e8f2fa0, which caused the macos-arm64 prebuilt LLVM link to run in the target configuration and crash the linux-amd64 prebuilt linker during CI.