### PR TITLE
Mark libgcc_s flag as universal scope

### DIFF
--- a/config/defs.bzl
+++ b/config/defs.bzl
@@ -143,6 +143,7 @@ def config_settings():
     bool_flag(
         name = "experimental_stub_libgcc_s",
         build_setting_default = False,
+        scope = "universal",
     )
 
     for sanitizer in SANITIZERS:


### PR DESCRIPTION
Otherwise it won't propagate to exec and then rust builds don't work because processwrapper doesn't build :)