### PR TITLE
glibc: link against rtld AS_NEEDED

### DIFF
--- a/runtimes/glibc/BUILD.bazel
+++ b/runtimes/glibc/BUILD.bazel
@@ -1,8 +1,8 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//toolchain:selects.bzl", "platform_extra_binary")
+load(":glibc_dynamic_linker.bzl", "glibc_dynamic_linker", "glibc_dynamic_linker_as_needed", "glibc_dynamic_linker_soname_flags")
 load(":glibc_linker_script.bzl", "make_glibc_linker_script")
 load(":glibc_shared_library.bzl", "make_glibc_shared_library")
 load(":glibc_stubs_assembly_files.bzl", "glibc_stubs_assembly_files")
@@ -56,72 +56,6 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-# The below are global symbols that are provided and initialized by the dynamic
-# linker (ld.so) when using glibc.
-#
-# To avoid having to compute the proper ld.so name in the linker script, we
-# resort to providing those symbols here.
-#
-# These symbols may not be normally available for all targets and versions of the
-# glibc but it should be "mostly" harmless.
-#
-# It might cause faulty programs to successfully link when they should not, even
-# tho the situations should be very rare or non-existent in practice.
-write_file(
-    name = "__stack_chk_guard.S",
-    out = "glibc/build/__stack_chk_guard.S",
-    content = [
-        ".globl __stack_chk_guard",
-        ".type __stack_chk_guard, %object;",
-        # TODO: Support 32 bit architectures,
-        #      Infer this from the target.
-        "#if __SIZEOF_POINTER__ == 4",
-        ".size __stack_chk_guard, 4",
-        "#else",
-        ".size __stack_chk_guard, 8",
-        "#endif",
-        # Will be relocated at runtime by the dynamic linker itself.
-        "__stack_chk_guard:",
-    ],
-)
-
-# Same as above.
-write_file(
-    name = "__libc_stack_end.S",
-    out = "glibc/build/__libc_stack_end.S",
-    content = [
-        ".globl __libc_stack_end",
-        ".type __libc_stack_end, %object;",
-        "#if __SIZEOF_POINTER__ == 4",
-        ".size __libc_stack_end, 4",
-        "#else",
-        ".size __libc_stack_end, 8",
-        "#endif",
-        # Will be relocated at runtime by the dynamic linker itself.
-        "__libc_stack_end:",
-    ],
-)
-
-# Same as above.
-write_file(
-    name = "__tls_get_addr.S",
-    out = "glibc/build/__tls_get_addr.S",
-    content = [
-        "#if __SIZEOF_POINTER__ == 4",
-        ".balign 4",
-        "#else",
-        ".balign 8",
-        "#endif",
-        ".globl __tls_get_addr",
-        ".type __tls_get_addr, %function;",
-        "#if __SIZEOF_POINTER__ == 4",
-        "__tls_get_addr: .long 0",
-        "#else",
-        "__tls_get_addr: .quad 0",
-        "#endif",
-    ],
-)
-
 # Make one cc_shared_library target per lib, using the assembly file
 LIBS = [
     make_glibc_shared_library(
@@ -129,18 +63,15 @@ LIBS = [
         srcs = [":lib" + lib + ".s"],
         lib_name = lib,
         lib_version = version,
+        soname = glibc_dynamic_linker() if lib == "ld" else None,
+        soname_link_flags = glibc_dynamic_linker_soname_flags() if lib == "ld" else None,
     )
     for (lib, version) in LIBC_SO_VERSIONS.items()
     if lib != "c"
 ] + [
     make_glibc_shared_library(
         name = "libc_shared_library",
-        srcs = [
-            ":__libc_stack_end.S",
-            ":__stack_chk_guard.S",
-            ":__tls_get_addr.S",
-            ":libc.s",
-        ],
+        srcs = [":libc.s"],
         extra_link_flags = [
             # _IO_stdin_used is defined as a global symbol in .rodata
             # and needs to be relocated at runtime with values from the CRTs.
@@ -160,11 +91,12 @@ LINKER_SCRIPTS = [
         additional_linker_inputs = [
             # we make it available in the search directory sibling to the libc.so
             "libc_nonshared.a",
-        ] if lib == "c" else [],
+        ] + glibc_dynamic_linker_as_needed() if lib == "c" else [],
         lib_name = lib,
         lib_version = version,
     )
     for (lib, version) in LIBC_SO_VERSIONS.items()
+    if lib != "ld"
 ]
 
 copy_file(
@@ -211,6 +143,12 @@ bzl_library(
     srcs = ["glibc_linker_script.bzl"],
     visibility = ["//visibility:public"],
     deps = ["@bazel_skylib//rules:write_file"],
+)
+
+bzl_library(
+    name = "glibc_dynamic_linker",
+    srcs = ["glibc_dynamic_linker.bzl"],
+    visibility = ["//visibility:public"],
 )
 
 bzl_library(

--- a/runtimes/glibc/BUILD.bazel
+++ b/runtimes/glibc/BUILD.bazel
@@ -146,12 +146,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "glibc_dynamic_linker",
-    srcs = ["glibc_dynamic_linker.bzl"],
-    visibility = ["//visibility:public"],
-)
-
-bzl_library(
     name = "glibc_shared_library",
     srcs = ["glibc_shared_library.bzl"],
     visibility = ["//visibility:public"],
@@ -169,6 +163,12 @@ bzl_library(
         "//constraints/libc:libc_versions",
         "//platforms:common",
     ],
+)
+
+bzl_library(
+    name = "glibc_dynamic_linker",
+    srcs = ["glibc_dynamic_linker.bzl"],
+    visibility = ["//visibility:public"],
 )
 
 bzl_library(

--- a/runtimes/glibc/glibc_dynamic_linker.bzl
+++ b/runtimes/glibc/glibc_dynamic_linker.bzl
@@ -1,0 +1,24 @@
+# Keep aligned with clang/lib/Driver/ToolChains/Linux.cpp from LLVM source code.
+_GLIBC_DYNAMIC_LINKERS = {
+    "//platforms/config:linux_aarch64_gnu": "ld-linux-aarch64.so.1",
+    "//platforms/config:linux_riscv64_gnu": "ld-linux-riscv64-lp64d.so.1",
+    "//platforms/config:linux_s390x_gnu": "ld64.so.1",
+    "//platforms/config:linux_x86_64_gnu": "ld-linux-x86-64.so.2",
+}
+
+_NO_MATCH_ERROR = "Unsupported glibc dynamic linker target. Add the target architecture to runtimes/glibc/glibc_dynamic_linker.bzl."
+
+def glibc_dynamic_linker():
+    return select(_GLIBC_DYNAMIC_LINKERS, no_match_error = _NO_MATCH_ERROR)
+
+def glibc_dynamic_linker_as_needed():
+    return select({
+        config: ["AS_NEEDED({})".format(dynamic_linker)]
+        for (config, dynamic_linker) in _GLIBC_DYNAMIC_LINKERS.items()
+    }, no_match_error = _NO_MATCH_ERROR)
+
+def glibc_dynamic_linker_soname_flags():
+    return select({
+        config: ["-Wl,-soname,{}".format(dynamic_linker)]
+        for (config, dynamic_linker) in _GLIBC_DYNAMIC_LINKERS.items()
+    }, no_match_error = _NO_MATCH_ERROR)

--- a/runtimes/glibc/glibc_linker_script.bzl
+++ b/runtimes/glibc/glibc_linker_script.bzl
@@ -4,13 +4,11 @@ def make_glibc_linker_script(name, lib_name, lib_version, additional_linker_inpu
     write_file(
         name = name,
         out = "lib{lib}.so".format(lib = lib_name),
-        content = [
-            # GROUP(file) is the same as INPUT(file) when there is just one file
-            "GROUP(lib{lib}.so.{version} {extra_inputs})".format(
-                lib = lib_name,
-                version = lib_version,
-                extra_inputs = " ".join(additional_linker_inputs),
-            ),
-        ],
+        # GROUP(file) is the same as INPUT(file) when there is just one file.
+        # Keep one input per line so callers can add configurable inputs.
+        content = ["GROUP(", "lib{lib}.so.{version}".format(
+            lib = lib_name,
+            version = lib_version,
+        )] + additional_linker_inputs + [")"],
     )
     return name

--- a/runtimes/glibc/glibc_shared_library.bzl
+++ b/runtimes/glibc/glibc_shared_library.bzl
@@ -6,6 +6,8 @@ def make_glibc_shared_library(
         lib_name,
         lib_version,
         srcs,
+        soname = None,
+        soname_link_flags = None,
         extra_link_flags = []):
     cc_library(
         name = "lib%s" % lib_name,
@@ -18,10 +20,12 @@ def make_glibc_shared_library(
         srcs = srcs,
     )
 
-    soname = "lib{lib}.so{version}".format(
-        lib = lib_name,
-        version = "." + lib_version if len(lib_version) > 0 else "",
-    )
+    if soname == None:
+        soname = "lib{lib}.so{version}".format(
+            lib = lib_name,
+            version = "." + lib_version if len(lib_version) > 0 else "",
+        )
+        soname_link_flags = ["-Wl,-soname,{}".format(soname)]
 
     # Stage0 because libc doesn't depend on anything at all
     cc_runtime_stage0_shared_library(
@@ -32,8 +36,7 @@ def make_glibc_shared_library(
         ],
         user_link_flags = [
             "-Wl,--version-script=$(location :all.map)",
-            "-Wl,-soname,{}".format(soname),
-        ] + extra_link_flags,
+        ] + soname_link_flags + extra_link_flags,
         shared_lib_name = soname,
         visibility = ["//visibility:public"],
     )


### PR DESCRIPTION
This way we provide the right rtld symbol stubs for the right architectures instead of hard coding it.

cc @fionera this might solve any future problem with missing rtld symbols. It's also the right thing to do.