### PR TITLE
Dedupe all header_directories

### DIFF
--- a/directory.bzl
+++ b/directory.bzl
@@ -51,4 +51,5 @@ _headers_directory = rule(
         "directory": attr.label(),
         "source_directory": attr.label(),
     },
+    cfg = config.none(),
 )


### PR DESCRIPTION
This way they are only analyzed once, not twice (for both toolchains)