### PR TITLE
Support the full matrix of runtimes as static and dynamic

### DIFF
--- a/3rd_party/gcc/gcc.BUILD.bazel
+++ b/3rd_party/gcc/gcc.BUILD.bazel
@@ -18,6 +18,7 @@ load(
     "libstdcxx_time_members_cc",
 )
 load("@llvm//toolchain/runtimes:cc_runtime_shared_library.bzl", "cc_runtime_stage1_shared_library")
+load("@llvm//toolchain/runtimes:cc_runtime_static_library.bzl", "cc_runtime_stage0_static_library")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -1151,6 +1152,12 @@ cc_library(
     }),
 )
 
+cc_runtime_stage0_static_library(
+    name = "libstdcxx.static",
+    visibility = ["//visibility:public"],
+    deps = [":libstdcxx"],
+)
+
 # The shared library version and linker flags should stay aligned with GCC's
 # libstdc++-v3/acinclude.m4 shared library and symbol-version settings.
 cc_runtime_stage1_shared_library(
@@ -1207,6 +1214,18 @@ cc_library(
     copts = LIBSTDCXX_LIBRARY_COPTS + ["-std=gnu++17"],
     implementation_deps = LIBSTDCXX_LIBRARY_DEPS,
     includes = LIBSTDCXX_LIBRARY_INCLUDES,
+)
+
+cc_runtime_stage0_static_library(
+    name = "libstdcxxfs.static",
+    visibility = ["//visibility:public"],
+    deps = [":libstdcxxfs"],
+)
+
+cc_runtime_stage0_static_library(
+    name = "libsupcxx.static",
+    visibility = ["//visibility:public"],
+    deps = [":libsupcxx"],
 )
 
 # Header search directory layout mirrors libstdc++-v3/include/Makefile.am:

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -84,9 +84,7 @@ cc_binary(
     srcs = ["main.cc"],
     linkstatic = False,
     target_compatible_with = select({
-        # We do not support musl libc.so
         "@platforms//os:windows": ["@platforms//:incompatible"],
-        "@llvm//constraints/libc:musl": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
 )
@@ -130,6 +128,35 @@ cc_binary(
     }),
 )
 
+cc_binary(
+    name = "libstdcxx_main_default",
+    srcs = ["main.cc"],
+    target_compatible_with = select({
+        "@llvm//constraints/cxxstdlib:libstdcxx": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }) + select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
+cc_binary(
+    name = "libstdcxx_main_default_with_linkopts",
+    srcs = ["main.cc"],
+    linkopts = [
+        "-lstdc++",
+        "-lstdc++fs",
+        "-lsupc++",
+    ],
+    target_compatible_with = select({
+        "@llvm//constraints/cxxstdlib:libstdcxx": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }) + select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)
+
 LIBSTDCXX_PLATFORMS = [
     ("linux_x86_64_libstdcxx", "@platforms//cpu:x86_64", "@llvm//constraints/libc:gnu.2.28"),
     ("linux_aarch64_libstdcxx", "@platforms//cpu:aarch64", "@llvm//constraints/libc:gnu.2.28"),
@@ -168,6 +195,20 @@ platform_transition_filegroup(
 platform_transition_filegroup(
     name = "libstdcxx_main_dynamic_with_linkopts_linux_x86_64",
     srcs = [":libstdcxx_main_dynamic_with_linkopts"],
+    target_compatible_with = _LIBSTDCXX_E2E_TARGET_COMPATIBLE_WITH,
+    target_platform = ":linux_x86_64_libstdcxx",
+)
+
+platform_transition_filegroup(
+    name = "libstdcxx_main_default_linux_x86_64",
+    srcs = [":libstdcxx_main_default"],
+    target_compatible_with = _LIBSTDCXX_E2E_TARGET_COMPATIBLE_WITH,
+    target_platform = ":linux_x86_64_libstdcxx",
+)
+
+platform_transition_filegroup(
+    name = "libstdcxx_main_default_with_linkopts_linux_x86_64",
+    srcs = [":libstdcxx_main_default_with_linkopts"],
     target_compatible_with = _LIBSTDCXX_E2E_TARGET_COMPATIBLE_WITH,
     target_platform = ":linux_x86_64_libstdcxx",
 )

--- a/runtimes/cxxstdlib/BUILD.bazel
+++ b/runtimes/cxxstdlib/BUILD.bazel
@@ -54,12 +54,26 @@ alias(
 )
 
 alias(
-    name = "library_search_directory",
+    name = "static_library_search_directory",
     actual = select({
-        ":libstdcxx_linux": "//runtimes/libstdcxx:libstdcxx_library_search_directory",
+        ":libstdcxx_linux": "//runtimes/libstdcxx:libstdcxx_static_library_search_directory",
         ":libstdcxx_windows": ":libstdcxx_windows_unsupported",
-        "//conditions:default": "//runtimes/libcxx:libcxx_library_search_directory",
+        "//conditions:default": "//runtimes/libcxx:libcxx_static_library_search_directory",
     }),
+)
+
+alias(
+    name = "dynamic_library_search_directory",
+    actual = select({
+        ":libstdcxx_linux": "//runtimes/libstdcxx:libstdcxx_dynamic_library_search_directory",
+        ":libstdcxx_windows": ":libstdcxx_windows_unsupported",
+        "//conditions:default": "//runtimes/libcxx:libcxx_dynamic_library_search_directory",
+    }),
+)
+
+alias(
+    name = "library_search_directory",
+    actual = ":dynamic_library_search_directory",
 )
 
 alias(
@@ -67,10 +81,9 @@ alias(
     actual = "//runtimes/libstdcxx:libstdcxx_shared_soname",
 )
 
-genrule(
+alias(
     name = "libstdcxx_static_runtime_lib",
-    outs = ["unsupported/libstdc++.a"],
-    cmd = "echo 'libstdc++ is only supported as a dynamic C++ runtime; static libstdc++ is intentionally unsupported.' >&2; exit 1",
+    actual = "//runtimes/libstdcxx:libstdcxx.static",
 )
 
 genrule(

--- a/runtimes/libcxx/BUILD.bazel
+++ b/runtimes/libcxx/BUILD.bazel
@@ -1,5 +1,5 @@
+load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("//runtimes:defs.bzl", "stub_library")
 
 alias(
     name = "libcxx.static",
@@ -25,20 +25,75 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-stub_library(
-    name = "c++",
+copy_file(
+    name = "libcxx_static_archive",
+    src = ":libcxx.static",
+    out = "static/libc++_archive.a",
+    allow_symlink = True,
 )
 
-stub_library(
-    name = "c++abi",
+copy_file(
+    name = "libcxxabi_static_archive",
+    src = ":libcxxabi.static",
+    out = "static/libc++abi.a",
+    allow_symlink = True,
+)
+
+genrule(
+    name = "libcxx_static_linker_script",
+    outs = ["static/libc++.a"],
+    cmd = "printf '%s\n' 'GROUP ( libc++_archive.a libc++abi.a )' > $@",
+)
+
+copy_file(
+    name = "libcxx_shared_soname",
+    src = ":libcxx.shared",
+    out = "dynamic/libc++.so.1",
+    allow_symlink = True,
+)
+
+copy_file(
+    name = "libcxxabi_shared_soname",
+    src = ":libcxxabi.shared",
+    out = "dynamic/libc++abi.so.1",
+    allow_symlink = True,
+)
+
+genrule(
+    name = "libcxx_shared_linker_script",
+    outs = ["dynamic/libc++.so"],
+    cmd = "printf '%s\n' 'GROUP ( libc++.so.1 libc++abi.so.1 )' > $@",
 )
 
 copy_to_directory(
-    name = "libcxx_library_search_directory",
+    name = "libcxx_static_library_search_directory",
     srcs = [
-        ":c++",
-        ":c++abi",
+        ":libcxx_static_archive",
+        ":libcxx_static_linker_script",
+        ":libcxxabi_static_archive",
     ],
+    replace_prefixes = {
+        "static": "",
+    },
+    visibility = ["//visibility:public"],
+)
+
+copy_to_directory(
+    name = "libcxx_dynamic_library_search_directory",
+    srcs = [
+        ":libcxx_shared_linker_script",
+        ":libcxx_shared_soname",
+        ":libcxxabi_shared_soname",
+    ],
+    replace_prefixes = {
+        "dynamic": "",
+    },
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libcxx_library_search_directory",
+    actual = ":libcxx_dynamic_library_search_directory",
     visibility = ["//visibility:public"],
 )
 

--- a/runtimes/libcxx/BUILD.bazel
+++ b/runtimes/libcxx/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 alias(
     name = "libcxx.static",
@@ -39,10 +40,10 @@ copy_file(
     allow_symlink = True,
 )
 
-genrule(
+write_file(
     name = "libcxx_static_linker_script",
-    outs = ["static/libc++.a"],
-    cmd = "printf '%s\n' 'GROUP ( libc++_archive.a libc++abi.a )' > $@",
+    out = "static/libc++.a",
+    content = ["GROUP ( libc++_archive.a libc++abi.a )"],
 )
 
 copy_file(
@@ -59,10 +60,10 @@ copy_file(
     allow_symlink = True,
 )
 
-genrule(
+write_file(
     name = "libcxx_shared_linker_script",
-    outs = ["dynamic/libc++.so"],
-    cmd = "printf '%s\n' 'GROUP ( libc++.so.1 libc++abi.so.1 )' > $@",
+    out = "dynamic/libc++.so",
+    content = ["GROUP ( libc++.so.1 libc++abi.so.1 )"],
 )
 
 copy_to_directory(

--- a/runtimes/libstdcxx/BUILD.bazel
+++ b/runtimes/libstdcxx/BUILD.bazel
@@ -324,8 +324,47 @@ alias(
 )
 
 alias(
+    name = "libstdcxx.static",
+    actual = "@gcc//:libstdcxx.static",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libstdcxxfs.static",
+    actual = "@gcc//:libstdcxxfs.static",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libsupcxx.static",
+    actual = "@gcc//:libsupcxx.static",
+    visibility = ["//visibility:public"],
+)
+
+alias(
     name = "libstdcxx_shared_soname",
     actual = ":libstdcxx.shared",
+)
+
+copy_file(
+    name = "libstdcxx_static_archive",
+    src = ":libstdcxx.static",
+    out = "static/libstdc++.a",
+    allow_symlink = True,
+)
+
+copy_file(
+    name = "libstdcxxfs_static_archive",
+    src = ":libstdcxxfs.static",
+    out = "static/libstdc++fs.a",
+    allow_symlink = True,
+)
+
+copy_file(
+    name = "libsupcxx_static_archive",
+    src = ":libsupcxx.static",
+    out = "static/libsupc++.a",
+    allow_symlink = True,
 )
 
 copy_file(
@@ -348,12 +387,31 @@ stub_library(
 )
 
 copy_to_directory(
-    name = "libstdcxx_library_search_directory",
+    name = "libstdcxx_static_library_search_directory",
     srcs = [
-        ":stdc++",
+        ":libstdcxx_static_archive",
+        ":libstdcxxfs_static_archive",
+        ":libsupcxx_static_archive",
+    ],
+    replace_prefixes = {
+        "static": "",
+    },
+    visibility = ["//visibility:public"],
+)
+
+copy_to_directory(
+    name = "libstdcxx_dynamic_library_search_directory",
+    srcs = [
+        ":libstdcxx_shared_linker_name",
         ":stdc++fs",
         ":supc++",
     ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libstdcxx_library_search_directory",
+    actual = ":libstdcxx_dynamic_library_search_directory",
     visibility = ["//visibility:public"],
 )
 

--- a/runtimes/libunwind/BUILD.bazel
+++ b/runtimes/libunwind/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//runtimes:defs.bzl", "stub_library")
 
 alias(
@@ -56,10 +57,10 @@ copy_file(
     visibility = ["//visibility:public"],
 )
 
-genrule(
+write_file(
     name = "libunwind_shared_linker_script",
-    outs = ["dynamic/libunwind.so"],
-    cmd = "printf '%s\n' 'GROUP ( libunwind.so.1 )' > $@",
+    out = "dynamic/libunwind.so",
+    content = ["GROUP ( libunwind.so.1 )"],
 )
 
 copy_to_directory(

--- a/runtimes/libunwind/BUILD.bazel
+++ b/runtimes/libunwind/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("//runtimes:defs.bzl", "stub_library")
 
@@ -13,8 +14,11 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-stub_library(
-    name = "unwind",
+copy_file(
+    name = "libunwind_static_archive",
+    src = ":libunwind.static",
+    out = "static/libunwind.a",
+    allow_symlink = True,
     visibility = ["//visibility:public"],
 )
 
@@ -31,12 +35,50 @@ config_setting(
 )
 
 copy_to_directory(
-    name = "libunwind_library_search_directory",
+    name = "libunwind_static_library_search_directory",
     srcs = [
-        ":unwind",
+        ":libunwind_static_archive",
     ] + select({
         ":stub_libgcc_s": [":gcc_s"],
         "//conditions:default": [],
     }),
+    replace_prefixes = {
+        "static": "",
+    },
+    visibility = ["//visibility:public"],
+)
+
+copy_file(
+    name = "libunwind_shared_soname",
+    src = ":libunwind.shared",
+    out = "dynamic/libunwind.so.1",
+    allow_symlink = True,
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "libunwind_shared_linker_script",
+    outs = ["dynamic/libunwind.so"],
+    cmd = "printf '%s\n' 'GROUP ( libunwind.so.1 )' > $@",
+)
+
+copy_to_directory(
+    name = "libunwind_dynamic_library_search_directory",
+    srcs = [
+        ":libunwind_shared_linker_script",
+        ":libunwind_shared_soname",
+    ] + select({
+        ":stub_libgcc_s": [":gcc_s"],
+        "//conditions:default": [],
+    }),
+    replace_prefixes = {
+        "dynamic": "",
+    },
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "libunwind_library_search_directory",
+    actual = ":libunwind_dynamic_library_search_directory",
     visibility = ["//visibility:public"],
 )

--- a/runtimes/musl/BUILD.bazel
+++ b/runtimes/musl/BUILD.bazel
@@ -105,11 +105,15 @@ cc_library(
 
 cc_runtime_stage0_shared_library(
     name = "musl_libc.shared",
+    additional_linker_inputs = ["//runtimes/compiler-rt:clang_rt.builtins.static"],
     user_link_flags = [
         "-Wl,-e,_dlstart",
         # should it be "now"?
         "-Wl,-z,now",
         "-Wl,-soname,libc.so",
+        "-Wl,--whole-archive",
+        "$(location //runtimes/compiler-rt:clang_rt.builtins.static)",
+        "-Wl,--no-whole-archive",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -229,7 +233,7 @@ MUSL_LIBS = [
 ]
 
 copy_to_directory(
-    name = "musl_library_search_directory",
+    name = "musl_static_library_search_directory",
     srcs = [
         ":musl_libc.a",
     ] + [
@@ -239,6 +243,26 @@ copy_to_directory(
     replace_prefixes = {
         "stubs": "",
     },
+    visibility = ["//visibility:public"],
+)
+
+copy_to_directory(
+    name = "musl_dynamic_library_search_directory",
+    srcs = [
+        ":musl_libc.so",
+    ] + [
+        ":musl_lib{}_stub".format(lib)
+        for lib in MUSL_LIBS
+    ],
+    replace_prefixes = {
+        "stubs": "",
+    },
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "musl_library_search_directory",
+    actual = ":musl_dynamic_library_search_directory",
     visibility = ["//visibility:public"],
 )
 

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -158,7 +158,6 @@ cc_args_list(
     }),
 )
 
-# Those are stubs since we link against static_runtime_libs / dynamic_runtime_libs.
 cc_args_list(
     name = "cxxstdlib_library_search_paths",
     args = select({
@@ -174,7 +173,6 @@ cc_args_list(
     }),
 )
 
-# Those are stubs since we link against static_runtime_libs / dynamic_runtime_libs.
 cc_args_list(
     name = "libunwind_library_search_paths",
     args = select({
@@ -236,7 +234,7 @@ cc_args_list(
 cc_args_list(
     name = "unwindlib",
     args = [
-        "//toolchain/args:unwindlib_none",
+        "//toolchain/args:unwindlib_libunwind",
     ],
 )
 
@@ -258,19 +256,13 @@ cc_args_list(
         "//toolchain/args:cxxstdlib_headers_include_search_paths",
     ] + select({
         "//platforms/config:musl": [
+            "//toolchain/args:static_link_executable",
             "//toolchain/args/linux:kernel_headers_include_search_paths",
             "//toolchain/args/linux:musl_libc_headers_include_search_paths",
         ],
         "//platforms/config:gnu": [
             "//toolchain/args/linux:kernel_headers_include_search_paths",
             "//toolchain/args/linux:glibc_headers_include_search_paths",
-        ],
-        "//conditions:default": [],
-    }) + select({
-        "//platforms/config:musl": [
-            #TODO: Handle musl dynamic linking
-            # musl implies static linking for now
-            "//toolchain/args:static_link_executable",
         ],
         "//conditions:default": [],
     }) + [

--- a/toolchain/args/BUILD.bazel
+++ b/toolchain/args/BUILD.bazel
@@ -1,9 +1,31 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature_constraint.bzl", "cc_feature_constraint")
 load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_args_list")
 load("//toolchain/args:llvm_target_triple.bzl", "LLVM_TARGET_TRIPLE")
 
 package(default_visibility = ["//visibility:public"])
+
+cc_feature_constraint(
+    name = "static_cpp_runtime_link_enabled",
+    all_of = [
+        "//toolchain/features:static_link_cpp_runtimes",
+        "//toolchain/features:static_linking_mode",
+    ],
+)
+
+cc_feature_constraint(
+    name = "dynamic_cpp_runtime_link_enabled",
+    all_of = [
+        "//toolchain/features:static_link_cpp_runtimes",
+        "//toolchain/features:dynamic_linking_mode",
+    ],
+)
+
+cc_feature_constraint(
+    name = "static_executable_link_enabled",
+    all_of = ["//toolchain/features:static_linking_mode"],
+)
 
 # COMMON RESET FLAGS
 # --no-default-config
@@ -165,6 +187,7 @@ cc_args(
         "//constraints/pie:on": ["-static-pie"],
         "//constraints/pie:off": ["-static"],
     }),
+    requires_any_of = [":static_executable_link_enabled"],
 )
 
 cc_args(
@@ -864,20 +887,19 @@ cc_args(
 )
 
 cc_args(
-    # We provide the libc++ and libunwind ourselves through static_runtime_libs
-    # and dynamic_runtime_libs.
     name = "stdlib",
     actions = [
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
-    args = [
-        # will prevent clang to choose which libc++ to link against
-        "-nostdlib++",
-    ],
+    args = select({
+        "//runtimes/cxxstdlib:libstdcxx_linux": ["-stdlib=libstdc++"],
+        "//runtimes/cxxstdlib:libstdcxx_windows": ["-stdlib=libstdc++"],
+        "//conditions:default": ["-stdlib=libc++"],
+    }),
 )
 
 cc_args(
-    name = "unwindlib_none",
+    name = "unwindlib_libunwind",
     actions = [
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
@@ -885,14 +907,12 @@ cc_args(
         # The clang driver forces -ISystem and doesn't claim the arg, which
         # would result in a warning when targeting macOS.
         "@platforms//os:macos": [],
-        # Will prevent clang from choosing which libunwind to link against.
-        "//conditions:default": ["--unwindlib=none"],
+        "//conditions:default": ["--unwindlib=libunwind"],
     }),
 )
 
-# Those are stubs since we link against static_runtime_libs / dynamic_runtime_libs.
 cc_args(
-    name = "cxxstdlib_library_search_paths",
+    name = "cxxstdlib_static_library_search_paths",
     actions = [
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
@@ -900,16 +920,41 @@ cc_args(
         "-L{cxxstdlib_library_search_path}",
     ],
     data = [
-        "//runtimes/cxxstdlib:library_search_directory",
+        "//runtimes/cxxstdlib:static_library_search_directory",
     ],
     format = {
-        "cxxstdlib_library_search_path": "//runtimes/cxxstdlib:library_search_directory",
+        "cxxstdlib_library_search_path": "//runtimes/cxxstdlib:static_library_search_directory",
     },
+    requires_any_of = [":static_cpp_runtime_link_enabled"],
 )
 
-# Those are stubs since we link against static_runtime_libs / dynamic_runtime_libs.
 cc_args(
-    name = "libunwind_library_search_paths",
+    name = "cxxstdlib_dynamic_library_search_paths",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = [
+        "-L{cxxstdlib_library_search_path}",
+    ],
+    data = [
+        "//runtimes/cxxstdlib:dynamic_library_search_directory",
+    ],
+    format = {
+        "cxxstdlib_library_search_path": "//runtimes/cxxstdlib:dynamic_library_search_directory",
+    },
+    requires_any_of = [":dynamic_cpp_runtime_link_enabled"],
+)
+
+cc_args_list(
+    name = "cxxstdlib_library_search_paths",
+    args = [
+        ":cxxstdlib_static_library_search_paths",
+        ":cxxstdlib_dynamic_library_search_paths",
+    ],
+)
+
+cc_args(
+    name = "libunwind_static_library_search_paths",
     actions = [
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
@@ -917,11 +962,37 @@ cc_args(
         "-L{libunwind_library_search_path}",
     ],
     data = [
-        "//runtimes/libunwind:libunwind_library_search_directory",
+        "//runtimes/libunwind:libunwind_static_library_search_directory",
     ],
     format = {
-        "libunwind_library_search_path": "//runtimes/libunwind:libunwind_library_search_directory",
+        "libunwind_library_search_path": "//runtimes/libunwind:libunwind_static_library_search_directory",
     },
+    requires_any_of = [":static_cpp_runtime_link_enabled"],
+)
+
+cc_args(
+    name = "libunwind_dynamic_library_search_paths",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = [
+        "-L{libunwind_library_search_path}",
+    ],
+    data = [
+        "//runtimes/libunwind:libunwind_dynamic_library_search_directory",
+    ],
+    format = {
+        "libunwind_library_search_path": "//runtimes/libunwind:libunwind_dynamic_library_search_directory",
+    },
+    requires_any_of = [":dynamic_cpp_runtime_link_enabled"],
+)
+
+cc_args_list(
+    name = "libunwind_library_search_paths",
+    args = [
+        ":libunwind_static_library_search_paths",
+        ":libunwind_dynamic_library_search_paths",
+    ],
 )
 
 cc_args(

--- a/toolchain/args/linux/BUILD.bazel
+++ b/toolchain/args/linux/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature_constraint.bzl", "cc_feature_constraint")
+load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_args_list")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -111,6 +113,16 @@ cc_args(
 
 ###
 
+cc_feature_constraint(
+    name = "static_libc_link_enabled",
+    all_of = ["//toolchain/features:static_linking_mode"],
+)
+
+cc_feature_constraint(
+    name = "dynamic_libc_link_enabled",
+    all_of = ["//toolchain/features:dynamic_linking_mode"],
+)
+
 cc_args(
     name = "musl_libc_headers_include_search_paths",
     actions = [
@@ -130,9 +142,9 @@ cc_args(
 
 #TODO: Factorize this and gnu
 cc_args(
-    name = "default_libs_musl",
+    name = "default_libs_musl_static",
     actions = [
-        "@rules_cc//cc/toolchains/actions:link_actions",
+        "@rules_cc//cc/toolchains/actions:link_executable_actions",
     ],
     args = [
         # We need to support copts like -lc -ldl etc...
@@ -149,11 +161,80 @@ cc_args(
         "-Wl,--pop-state",
     ],
     data = [
-        "//runtimes/musl:musl_library_search_directory",
+        "//runtimes/musl:musl_static_library_search_directory",
     ],
     format = {
-        "libc_library_search_path": "//runtimes/musl:musl_library_search_directory",
+        "libc_library_search_path": "//runtimes/musl:musl_static_library_search_directory",
     },
+    requires_any_of = [":static_libc_link_enabled"],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+#TODO: Factorize this and gnu
+cc_args(
+    name = "default_libs_musl_dynamic_executable",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_executable_actions",
+    ],
+    args = [
+        # We need to support copts like -lc -ldl etc...
+        "-L{libc_library_search_path}",
+
+        # In prevention of when all of those can be shared libraries.
+        "-Wl,--push-state",
+        "-Wl,--as-needed",
+
+        # Since libunwind is linked dynamically, these are only compatibility
+        # search entries. musl provides the symbols from libc.so.
+        "-lpthread",
+        "-ldl",
+        "-Wl,--pop-state",
+    ],
+    data = [
+        "//runtimes/musl:musl_dynamic_library_search_directory",
+    ],
+    format = {
+        "libc_library_search_path": "//runtimes/musl:musl_dynamic_library_search_directory",
+    },
+    requires_any_of = [":dynamic_libc_link_enabled"],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+cc_args(
+    name = "default_libs_musl_dynamic_library",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:dynamic_library_link_actions",
+    ],
+    args = [
+        # We need to support copts like -lc -ldl etc...
+        "-L{libc_library_search_path}",
+
+        # In prevention of when all of those can be shared libraries.
+        "-Wl,--push-state",
+        "-Wl,--as-needed",
+
+        # Since libunwind is linked dynamically, these are only compatibility
+        # search entries. musl provides the symbols from libc.so.
+        "-lpthread",
+        "-ldl",
+        "-Wl,--pop-state",
+    ],
+    data = [
+        "//runtimes/musl:musl_dynamic_library_search_directory",
+    ],
+    format = {
+        "libc_library_search_path": "//runtimes/musl:musl_dynamic_library_search_directory",
+    },
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+cc_args_list(
+    name = "default_libs_musl",
+    args = [
+        ":default_libs_musl_static",
+        ":default_libs_musl_dynamic_executable",
+        ":default_libs_musl_dynamic_library",
+    ],
     target_compatible_with = ["@platforms//os:linux"],
 )
 

--- a/toolchain/args/linux/BUILD.bazel
+++ b/toolchain/args/linux/BUILD.bazel
@@ -4,6 +4,14 @@ load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_args_list")
 
 package(default_visibility = ["//visibility:public"])
 
+_GNU_SPLIT_PTHREAD_DL_LINK_ARGS = [
+    "-Wl,--push-state",
+    "-Wl,--as-needed",
+    "-lpthread",
+    "-ldl",
+    "-Wl,--pop-state",
+]
+
 # Extracted from rules_cc unix_cc_configure.bzl
 # TODO(cerisier): Extract those into proper semantic args list.
 cc_args(
@@ -90,19 +98,24 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
     args = [
-        # We need to support copts like -lc -ldl etc...
+        # Expose the hermetic libc directory to the driver and to user-supplied
+        # linkopts like -lc or -ldl.
         "-L{libc_library_search_path}",
-
-        # In prevention of when all of those can be shared libraries.
-        "-Wl,--push-state",
-        "-Wl,--as-needed",
-
-        # Since libunwind is linked statically, we need to link pthread as well.
-        "-lpthread",
-        # Since libunwind is linked statically, we need to link dl as well.
-        "-ldl",
-        "-Wl,--pop-state",
-    ],
+    ] + select({
+        # Before glibc 2.34, libpthread and libdl are separate libraries. The
+        # Clang driver only adds -lc, but our GNU libc++/libunwind runtimes can
+        # leave pthread/dl references for the final link.
+        "//constraints/libc:gnu.2.28": _GNU_SPLIT_PTHREAD_DL_LINK_ARGS,
+        "//constraints/libc:gnu.2.29": _GNU_SPLIT_PTHREAD_DL_LINK_ARGS,
+        "//constraints/libc:gnu.2.30": _GNU_SPLIT_PTHREAD_DL_LINK_ARGS,
+        "//constraints/libc:gnu.2.31": _GNU_SPLIT_PTHREAD_DL_LINK_ARGS,
+        "//constraints/libc:gnu.2.32": _GNU_SPLIT_PTHREAD_DL_LINK_ARGS,
+        "//constraints/libc:gnu.2.33": _GNU_SPLIT_PTHREAD_DL_LINK_ARGS,
+        # Custom Linux platforms without an explicit libc constraint are routed
+        # to GNU. Treat them as pre-2.34 to keep old-glibc runtimes linkable.
+        "//constraints/libc:unconstrained": _GNU_SPLIT_PTHREAD_DL_LINK_ARGS,
+        "//conditions:default": [],
+    }),
     data = [
         "//runtimes/glibc:glibc_library_search_directory",
     ],
@@ -147,18 +160,9 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:link_executable_actions",
     ],
     args = [
-        # We need to support copts like -lc -ldl etc...
+        # Expose the hermetic libc directory to the driver and to user-supplied
+        # linkopts like -lc or -ldl.
         "-L{libc_library_search_path}",
-
-        # In prevention of when all of those can be shared libraries.
-        "-Wl,--push-state",
-        "-Wl,--as-needed",
-
-        # Since libunwind is linked statically, we need to link pthread as well.
-        "-lpthread",
-        # Since libunwind is linked statically, we need to link dl as well.
-        "-ldl",
-        "-Wl,--pop-state",
     ],
     data = [
         "//runtimes/musl:musl_static_library_search_directory",
@@ -177,18 +181,9 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:link_executable_actions",
     ],
     args = [
-        # We need to support copts like -lc -ldl etc...
+        # Expose the hermetic libc directory to the driver and to user-supplied
+        # linkopts like -lc or -ldl.
         "-L{libc_library_search_path}",
-
-        # In prevention of when all of those can be shared libraries.
-        "-Wl,--push-state",
-        "-Wl,--as-needed",
-
-        # Since libunwind is linked dynamically, these are only compatibility
-        # search entries. musl provides the symbols from libc.so.
-        "-lpthread",
-        "-ldl",
-        "-Wl,--pop-state",
     ],
     data = [
         "//runtimes/musl:musl_dynamic_library_search_directory",
@@ -206,18 +201,9 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:dynamic_library_link_actions",
     ],
     args = [
-        # We need to support copts like -lc -ldl etc...
+        # Expose the hermetic libc directory to the driver and to user-supplied
+        # linkopts like -lc or -ldl.
         "-L{libc_library_search_path}",
-
-        # In prevention of when all of those can be shared libraries.
-        "-Wl,--push-state",
-        "-Wl,--as-needed",
-
-        # Since libunwind is linked dynamically, these are only compatibility
-        # search entries. musl provides the symbols from libc.so.
-        "-lpthread",
-        "-ldl",
-        "-Wl,--pop-state",
     ],
     data = [
         "//runtimes/musl:musl_dynamic_library_search_directory",

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -35,6 +35,8 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             #"@rules_cc//cc/toolchains/args/layering_check:use_module_maps",
             "@llvm//toolchain/features:archive_param_file",
             "@llvm//toolchain/features:prefer_pic_for_opt_binaries",
+            "@llvm//toolchain/features:static_linking_mode",
+            "@llvm//toolchain/features:dynamic_linking_mode",
             # Always last (contains user_compile_flags and user_link_flags who should apply last).
             "@llvm//toolchain/features/legacy:experimental_replace_legacy_action_config_features",
         ],
@@ -118,13 +120,13 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             "@llvm//toolchain:runtimes_none": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1_hosted": "@llvm//runtimes:none",
-            "//conditions:default": "@llvm//runtimes:static_runtime_lib",
+            "//conditions:default": "@llvm//runtimes:none",
         }),
         dynamic_runtime_lib = select({
             "@llvm//toolchain:runtimes_none": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1_hosted": "@llvm//runtimes:none",
-            "//conditions:default": "@llvm//runtimes:dynamic_runtime_lib",
+            "//conditions:default": "@llvm//runtimes:none",
         }),
         compiler = "clang",
     )

--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -13,6 +13,16 @@ package(default_visibility = ["//visibility:public"])
 # [x] static_link_cpp_runtimes
 
 cc_feature(
+    name = "static_linking_mode",
+    overrides = "@rules_cc//cc/toolchains/features:static_linking_mode",
+)
+
+cc_feature(
+    name = "dynamic_linking_mode",
+    overrides = "@rules_cc//cc/toolchains/features:dynamic_linking_mode",
+)
+
+cc_feature(
     name = "static_link_cpp_runtimes",
     overrides = "@rules_cc//cc/toolchains/features:static_link_cpp_runtimes",
 )
@@ -239,6 +249,8 @@ cc_feature_set(
         ":opt_stub",
         ":dbg",
         ":dbg_stub",
+        ":static_linking_mode",
+        ":dynamic_linking_mode",
         ":static_link_cpp_runtimes",
         ":parse_headers",
         # TODO: Re-enable once coverage is supported

--- a/toolchain/runtimes/BUILD.bazel
+++ b/toolchain/runtimes/BUILD.bazel
@@ -27,19 +27,13 @@ cc_args_list(
     name = "linux_hosted_c_toolchain_args",
     args = select({
         "//platforms/config:musl": [
+            "//toolchain/args:static_link_executable",
             "//toolchain/args/linux:kernel_headers_include_search_paths",
             "//toolchain/args/linux:musl_libc_headers_include_search_paths",
         ],
         "//platforms/config:gnu": [
             "//toolchain/args/linux:kernel_headers_include_search_paths",
             "//toolchain/args/linux:glibc_headers_include_search_paths",
-        ],
-        "//conditions:default": [],
-    }) + select({
-        "//platforms/config:musl": [
-            # TODO: Handle musl dynamic linking.
-            # musl implies static linking for now.
-            "//toolchain/args:static_link_executable",
         ],
         "//conditions:default": [],
     }) + [


### PR DESCRIPTION
## Summary

This PR moves runtime selection out of `cc_toolchain.static_runtime_lib` / `dynamic_runtime_lib` and into rule-based toolchain features.

Runtime libraries and related link inputs are now attached to `cc_args(data = ...)` gated by `static_linking_mode` / `dynamic_linking_mode`. This makes the
selected link mode determine which runtime artifacts enter the link action, instead of relying on opaque `cc_toolchain` runtime attributes.

## Driver-Based Runtime Linking

This also shifts more responsibility back to the compiler driver.

Instead of having rules_cc force runtime linker inputs directly, the toolchain now provides the driver with the right sysroot and library search inputs, then lets   the driver expand the standard runtime `-l` behavior where possible. As part of that, this removes more `-nostd*` flags and only keeps explicit linker flags where the driver cannot infer them reliably.

## Runtime Coverage

This PR also adds missing static or dynamic counterparts for existing runtimes, most notably:

- static `libstdc++`
- dynamic `musl`
- matching static/dynamic handling for runtimes that were previously one-sided

glibc remains dynamic-only for now because it is still represented through the existing stub path.

## Behavior Changes

A key behavior change is that binaries and tests can now select different runtime inputs in all supported configurations.

For example, a `cc_binary` may be linked statically while a `cc_test` is linked dynamically, so they may compile, link, and load different runtime artifacts.
Previously this behavior mostly applied to `libc++` and `libunwind`; now it applies consistently across the runtime set, except for glibc, which remains unconditionally dynamic.

## Runtime Discovery

This PR does not configure runtime rpaths.

Dynamically linked outputs must rely on the loader’s normal search behavior or external runtime setup. This change is only about correct link-time input and argument selection, not runtime library discovery.