### PR TITLE
Add opt-in libclang prebuilt tarball

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -54,6 +54,32 @@ LLVM_TOOLCHAIN_MINIMAL_SHA256 = {
     for (target, sha256) in LLVM_TOOLCHAIN_MINIMAL_SHA256.items()
 ]
 
+# Opt-in libclang tarballs. Separate from the minimal llvm tarball so
+# consumers who don't reference @llvm_toolchains//:libclang never fetch
+# (http_archive is lazy). Linux-only; add darwin/windows once the
+# cc_plugin_library outputs are verified on those exec platforms.
+LIBCLANG_SHA256 = {
+    "linux-amd64-musl": "TODO: populate after first libclang_release build",
+    "linux-arm64-musl": "TODO: populate after first libclang_release build",
+}
+
+[
+    http_archive(
+        name = "libclang-toolchain-{llvm_version}-{target}".format(
+            llvm_version = PREBUILT_LLVM_VERSION,
+            target = target.replace("-musl", ""),
+        ),
+        build_file = "//prebuilt/libclang:libclang.BUILD.bazel",
+        sha256 = sha256,
+        urls = ["https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-{llvm_version}{prebuilt_llvm_suffix}/libclang-toolchain-{llvm_version}-{target}.tar.zst".format(
+            llvm_version = PREBUILT_LLVM_VERSION,
+            prebuilt_llvm_suffix = PREBUILT_LLVM_SUFFIX,
+            target = target,
+        )],
+    )
+    for (target, sha256) in LIBCLANG_SHA256.items()
+]
+
 TOOLCHAIN_EXTRAS_SHA256 = {
     "darwin-amd64": "7f982146b033650295a568e2db2795753d6610919c4d0e90bc4baf53dfb88d04",
     "darwin-arm64": "4244309df7e1cb3c602597dc30b2cf25064960b877e8087dfaaa2c3f57580588",

--- a/extensions/toolchain.bzl
+++ b/extensions/toolchain.bzl
@@ -3,6 +3,7 @@ load("//platforms:common.bzl", "SUPPORTED_EXECS", "SUPPORTED_TARGETS")
 _BUILD_TEMPLATE = """\
 load("@llvm//toolchain:declare_toolchains.bzl", "declare_toolchains")
 load("@llvm//toolchain/bootstrap:declare_toolchains.bzl", declare_bootstrap_toolchains = "declare_toolchains")
+load("@llvm_config//:version.bzl", "LLVM_VERSION")
 
 _EXECS = [
     {execs}
@@ -14,6 +15,19 @@ _TARGETS = [
 
 declare_toolchains(execs = _EXECS, targets = _TARGETS)
 declare_bootstrap_toolchains(execs = _EXECS, targets = _TARGETS)
+
+# Canonical label for downstream bindgen / clang-sys consumers wiring
+# LIBCLANG_PATH. The libclang tarball is fetched lazily by the http_archive
+# in the root MODULE.bazel — consumers that never reference this alias
+# pay no download / analysis cost. Linux-only initially.
+alias(
+    name = "libclang",
+    actual = select({{
+        "@llvm//platforms/config:linux_x86_64": "@libclang-toolchain-" + LLVM_VERSION + "-linux-amd64//:libclang",
+        "@llvm//platforms/config:linux_aarch64": "@libclang-toolchain-" + LLVM_VERSION + "-linux-arm64//:libclang",
+    }}),
+    visibility = ["//visibility:public"],
+)
 """
 
 def _toolchains_repository_impl(rctx):

--- a/prebuilt/libclang/BUILD.bazel
+++ b/prebuilt/libclang/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("//prebuilt/libclang:libclang_release.bzl", "libclang_release")
+
+# Platforms for which we produce a libclang tarball. Linux-only in v1.
+_LIBCLANG_PLATFORMS = [
+    "//platforms:linux_amd64_musl",
+    "//platforms:linux_arm64_musl",
+]
+
+exports_files(["libclang.BUILD.bazel"])
+
+libclang_release(name = "libclang_release")
+
+[
+    platform_transition_filegroup(
+        name = "for_" + platform.split(":")[1],
+        srcs = [":libclang_release"],
+        target_platform = platform,
+    )
+    for platform in _LIBCLANG_PLATFORMS
+]
+
+filegroup(
+    name = "for_all_platforms",
+    srcs = ["for_" + platform.split(":")[1] for platform in _LIBCLANG_PLATFORMS],
+)
+
+bzl_library(
+    name = "libclang_release",
+    srcs = ["libclang_release.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prebuilt:mtree",
+        "@tar.bzl//tar",
+    ],
+)

--- a/prebuilt/libclang/libclang.BUILD.bazel
+++ b/prebuilt/libclang/libclang.BUILD.bazel
@@ -1,0 +1,12 @@
+# BUILD file for the unpacked libclang prebuilt tarball.
+# Exposes a single public `libclang` file label that downstream
+# bindgen / clang-sys consumers reference via $(execpath ...)
+# for LIBCLANG_PATH.
+
+exports_files(["lib/libclang.so"])
+
+filegroup(
+    name = "libclang",
+    srcs = ["lib/libclang.so"],
+    visibility = ["//visibility:public"],
+)

--- a/prebuilt/libclang/libclang_release.bzl
+++ b/prebuilt/libclang/libclang_release.bzl
@@ -1,0 +1,34 @@
+load("@tar.bzl//tar:tar.bzl", "tar")
+load("//prebuilt:mtree.bzl", "mtree")
+
+# Builds an opt-in tarball containing only libclang for downstream
+# bindgen / clang-sys consumers wiring LIBCLANG_PATH. Kept separate from
+# the main llvm_release tarball so consumers who don't need libclang pay
+# nothing for it (the http_archive only fetches when a label inside is
+# referenced).
+#
+# v1 scope: Linux only. Upstream cc_plugin_library generates
+# per-platform single-file targets (:libclang.so, :libclang.dylib,
+# :libclang.dll); macOS / Windows can be added once tested on those execs.
+def libclang_release(name):
+    files = {
+        "@llvm-project//clang:libclang.so": "lib/libclang.so",
+    }
+
+    mtree(
+        name = name + "_mtree",
+        files = files,
+        tags = ["manual"],
+    )
+
+    tar(
+        name = name,
+        srcs = files.keys(),
+        args = [
+            "--options",
+            "zstd:compression-level=22",
+        ],
+        compress = "zstd",
+        mtree = name + "_mtree",
+        tags = ["manual"],
+    )


### PR DESCRIPTION
## Summary

- Adds a separate, opt-in libclang prebuilt tarball under `prebuilt/libclang/` so downstream consumers using bindgen / clang-sys can resolve `LIBCLANG_PATH` to a Bazel-tracked file on hermetic / remote workers.
- Does **not** add libclang to the main minimal llvm tarball — bundling it would bloat the download (~30-50MB compressed) for every consumer.
- Exposes a stable `@llvm_toolchains//:libclang` alias selected across supported Linux exec config_settings so consumers don't have to spell out Bzlmod-mangled repo names.

## Motivation

`clang-sys` (used by `bindgen`) `dlopen`s libclang at build-script runtime via the `LIBCLANG_PATH` env var. Without libclang reachable through Bazel, downstream Rust crates that bindgen against C/C++ headers can't run their build scripts on hermetic / RBE workers.

## Design

Mirrors the existing `prebuilt/extras/` pattern:

- `prebuilt/libclang/libclang_release.bzl` — `libclang_release(name)` produces a single-file `tar.zst` containing `lib/libclang.so` sourced from `@llvm-project//clang:libclang.so` (cc_plugin_library output).
- `prebuilt/libclang/BUILD.bazel` — invokes the rule and emits per-platform `platform_transition_filegroup`s.
- `prebuilt/libclang/libclang.BUILD.bazel` — build_file for the unpacked tarball; exposes a public `:libclang` filegroup.
- `MODULE.bazel` — `LIBCLANG_SHA256` dict + `http_archive` loop parallel to `TOOLCHAIN_EXTRAS_SHA256`. **Lazy fetch**: consumers that never reference `@llvm_toolchains//:libclang` never download.
- `extensions/toolchain.bzl` — alias with `select()` on `@llvm//platforms/config:linux_{x86_64,aarch64}`. Non-Linux exec → no matching condition → clear analysis error.

## Why \"no bloat\" for non-users

Bazel's `http_archive` is lazy: a repo is materialized only when a label inside it is referenced. Consumers that don't touch `@llvm_toolchains//:libclang` (or anything inside `@libclang-toolchain-*`) never download the tarball. No opt-in tag needed.

## Status: **draft**

- `LIBCLANG_SHA256` values are placeholders. Real shas will be filled once the first libclang tarballs are published to the `hermetic-llvm` releases.
- Linux x86_64 and aarch64 only. macOS (`libclang.dylib`) and Windows (`libclang.dll`) can be added by extending `_LIBCLANG_PLATFORMS` and `LIBCLANG_SHA256` once `cc_plugin_library` outputs are validated on those execs.
- Looking for design feedback before publishing tarballs:
  - Is `prebuilt/libclang/` the right home, or do you prefer this under `prebuilt/extras/`?
  - Naming: `libclang` vs `libclang_so` vs `clang_lib`?
  - Should the canonical label live at `@llvm_toolchains//:libclang` (current proposal) or be platform-transitioned via `@llvm//:libclang_for_<platform>` consistent with `prebuilt/llvm/BUILD.bazel`?

## Downstream usage

```python
crate.annotation(
    crate = \"clang-sys\",
    build_script_env = {
        \"LIBCLANG_PATH\": \"\$\${pwd}/\$(execpath @llvm_toolchains//:libclang)\",
    },
    build_script_data = [\"@llvm_toolchains//:libclang\"],
)
```

## Test plan

- [ ] Build libclang tarballs for linux x86_64 / aarch64, populate `LIBCLANG_SHA256`, publish to a `hermetic-llvm` release.
- [ ] Verify downstream Rust crate using bindgen/clang-sys can resolve libclang via `@llvm_toolchains//:libclang` on a hermetic worker.
- [ ] Re-run with `--sandbox_block_path=/usr/lib/x86_64-linux-gnu/libclang-*.so` to confirm system libclang is not leaking in.