### PR TITLE
Fix OSX SDK download

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -125,7 +125,7 @@ osx.from_archive(
     type = "pkg",
     urls = [
         "https://swcdn.apple.com/content/downloads/60/13/122-35686-A_30JUXWIJFR/ck0gzuw5qccefzm3ptlwou3pu6a55d0o02/CLTools_macOSNMOS_SDK.pkg",
-        "https://web.archive.org/web/20260430051604/https://swcdn.apple.com/content/downloads/60/13/122-35686-A_30JUXWIJFR/ck0gzuw5qccefzm3ptlwou3pu6a55d0o02/CLTools_macOSNMOS_SDK.pkg",
+        "https://web.archive.org/web/20260430051604id_/https://swcdn.apple.com/content/downloads/60/13/122-35686-A_30JUXWIJFR/ck0gzuw5qccefzm3ptlwou3pu6a55d0o02/CLTools_macOSNMOS_SDK.pkg",
     ],
 )
 use_repo(osx, "macos_sdk")


### PR DESCRIPTION
The previous URL served a redirect which some remote downloaders seem to not follow. Dereference it manually.