### PR TITLE
Update LLVM to 22.1.7

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ rbe_platform_repository(
     name = "rbe_platform",
 )
 
-LLVM_VERSION = "22.1.6"
+LLVM_VERSION = "22.1.7"
 
 PREBUILT_LLVM_VERSION = "22.1.6"
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,17 +24,17 @@ rbe_platform_repository(
 
 LLVM_VERSION = "22.1.7"
 
-PREBUILT_LLVM_VERSION = "22.1.6"
+PREBUILT_LLVM_VERSION = "22.1.7"
 
 PREBUILT_LLVM_SUFFIX = "-1"
 
 LLVM_TOOLCHAIN_MINIMAL_SHA256 = {
-    "darwin-amd64": "cc79ad7858a02589b334643b38b7112cb2ca7a7546dfefca3feee244f58c209e",
-    "darwin-arm64": "da43c29334d92d232f7951ce7be23cf5958f9388fa02ba75a87600a5900b2d52",
-    "linux-amd64-musl": "19ecc9a5a3eedd00d7a46e35b292a908ec4eba4f33a40d2566e9a1d2cce31d85",
-    "linux-arm64-musl": "3bef1e2cd4de0b35d5305a00d125b8a3257b926171f71ab95bc4ca755fee1647",
-    "windows-amd64": "225a8da883543ecd8df865457931d09f38e344243901ad97ddc1fc2a2266563a",
-    "windows-arm64": "31f6c4637a27028ad5251ce7aa4ed244f744190eac90cfe7755a7a5d91b11b40",
+    "darwin-amd64": "ee5b1e8b7bc2914da7439850321d7216d6367dfb138c4faa6bc6a5c046abaf21",
+    "darwin-arm64": "83259015d1e7fe11cd3ab14df2f442da2754c88fb502f1e81789d2ed8ff166a2",
+    "linux-amd64-musl": "8005a453f3f870bfd19ceda7781ed85d41a9d976d8a40a747f88ca41665b4315",
+    "linux-arm64-musl": "ba5f8078fd665fd43c8c5d1fcffd4908e130e2b6a4fdf1e281316508f6e9e9fb",
+    "windows-amd64": "d8a302fb3d752aa7cd18800ec4cf52ca81c1c6cd547ecfa913629c7a7ea9202d",
+    "windows-arm64": "6adee51f1cdf8bce4141b031e865ff012f359b36d527cbfb74064441328785be",
 }
 
 [

--- a/llvm_versions.json
+++ b/llvm_versions.json
@@ -30,5 +30,9 @@
   "22.1.6": {
     "url": "https://github.com/hermeticbuild/llvm-redist/releases/download/llvmorg-22.1.6-r1/llvm-project-22.1.6.src.tar.zst",
     "sha256": "3531ec19b939c868bd82e72c0efde674fb6cf942a2f64dbf573a069e8b0d4d2b"
+  },
+  "22.1.7": {
+    "url": "https://github.com/hermeticbuild/llvm-redist/releases/download/llvmorg-22.1.7-r1/llvm-project-22.1.7.src.tar.zst",
+    "sha256": "6ef7e6986ef1fd5a0074f249e161977c7c0e47d2a9eebcdb9fc1ddf483223aad"
   }
 }

--- a/toolchain/selects.bzl
+++ b/toolchain/selects.bzl
@@ -1,4 +1,4 @@
-LLVM_VERSION = "22.1.6"
+LLVM_VERSION = "22.1.7"
 
 def platform_llvm_binary(binary):
     return select({


### PR DESCRIPTION
## Summary

- add LLVM 22.1.7 source metadata from hermeticbuild/llvm-redist
- consume `llvm-22.1.7-1` minimal prebuilts in `MODULE.bazel`
- update `toolchain/selects.bzl` to select LLVM 22.1.7 prebuilts

This branch is now rebased on `main` after #587. It no longer carries the temporary macOS `--ld-path` workaround commits or the canceled MSan test tag change.

## Verification

- LLVM Prebuilt Release run `26877886126` attempt 2 succeeded
- release `llvm-22.1.7-1` contains `SHA256.txt` and all six minimal toolchain archives
- `MODULE.bazel` checksums match release `SHA256.txt`
- PR CI rerun `26899536585` is running after the cleaned branch push
