### PR TITLE
Implement `external_include_paths`

### DIFF
--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -12,6 +12,7 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             "@llvm//toolchain/features:archive_param_file",
             "@llvm//toolchain/features:prefer_pic_for_opt_binaries",
             "@llvm//toolchain/features:parse_headers",
+            "@llvm//toolchain/features:external_include_paths",
         ] + select({
             "@platforms//os:linux": [
                 "@rules_cc//cc/toolchains/args/thin_lto:feature",

--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -30,6 +30,14 @@ cc_feature(
     feature_name = "prefer_pic_for_opt_binaries",
 )
 
+# Allow external repositories to get included with -isystem instead of -I.
+# in order to silence warnings from external headers.
+cc_feature(
+    name = "external_include_paths",
+    args = ["@rules_cc//cc/toolchains/args/external_include_paths:external_include_paths"],
+    feature_name = "external_include_paths",
+)
+
 cc_args(
     name = "opt_link_flags",
     actions = [


### PR DESCRIPTION
Implement `external_include_paths` which was added to the rule-based toolchain in https://github.com/bazelbuild/rules_cc/pull/323.

Setting `--features=external_include_paths` alters the `-I` to `-isystem` and helps to silence warnings from external headers.

Unsure how to implement a proper integration test.