### PR TITLE
Configure link wrapper tools in exec config

### DIFF
--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -214,28 +214,6 @@ def declare_tool_map(exec_os, exec_cpu):
         ],
     )
 
-    cc_args(
-        name = prefix + "/link-wrapper-args",
-        actions = [
-            "@rules_cc//cc/toolchains/actions:link_actions",
-        ],
-        data = [
-            prefix + "/bin/clang++",
-            prefix + "/bin/dsymutil",
-            prefix + "/bin/llvm-strip",
-        ],
-        env = {
-            "LLVM_CLANGXX": "{clangxx}",
-            "LLVM_DSYMUTIL": "{dsymutil}",
-            "LLVM_STRIP": "{strip}",
-        },
-        format = {
-            "clangxx": prefix + "/bin/clang++",
-            "dsymutil": prefix + "/bin/dsymutil",
-            "strip": prefix + "/bin/llvm-strip",
-        },
-    )
-
     bootstrap_binary(
         name = prefix + "/bin/ld.lld",
         platform = prefix + "_platform",
@@ -283,6 +261,16 @@ def declare_tool_map(exec_os, exec_cpu):
             prefix + "/bin/lld",
             prefix + "/bin/wasm-ld",
         ],
+        env = {
+            "LLVM_CLANGXX": "{clangxx}",
+            "LLVM_DSYMUTIL": "{dsymutil}",
+            "LLVM_STRIP": "{strip}",
+        },
+        format = {
+            "clangxx": prefix + "/bin/clang++",
+            "dsymutil": prefix + "/bin/dsymutil",
+            "strip": prefix + "/bin/llvm-strip",
+        },
     )
 
     bootstrap_binary(
@@ -390,12 +378,7 @@ def declare_toolchains(*, execs = None, targets = SUPPORTED_TARGETS):
             extra_args = [
                 ":{}_{}/header-parser-args".format(exec_os, exec_cpu),
                 ":{}_{}/static-library-validator-args".format(exec_os, exec_cpu),
-            ] + select({
-                "@llvm//toolchain:macos_complete": [
-                    ":{}_{}/link-wrapper-args".format(exec_os, exec_cpu),
-                ],
-                "//conditions:default": [],
-            }),
+            ],
         )
 
         for (target_os, target_cpu) in targets:

--- a/toolchain/declare_toolchains.bzl
+++ b/toolchain/declare_toolchains.bzl
@@ -1,5 +1,5 @@
 load("//platforms:common.bzl", "SUPPORTED_EXECS", "SUPPORTED_TARGETS")
-load("//toolchain:selects.bzl", "header_parser_arg", "link_wrapper_arg", "platform_cc_tool_map", "platform_module_map", "resource_dir_arg", "static_library_validator_arg")
+load("//toolchain:selects.bzl", "header_parser_arg", "platform_cc_tool_map", "platform_module_map", "resource_dir_arg", "static_library_validator_arg")
 load(":cc_toolchain.bzl", "cc_toolchain")
 
 def declare_toolchains(*, execs = SUPPORTED_EXECS, targets = SUPPORTED_TARGETS):
@@ -23,7 +23,7 @@ def declare_toolchains(*, execs = SUPPORTED_EXECS, targets = SUPPORTED_TARGETS):
                 resource_dir_arg(exec_os, exec_cpu),
                 header_parser_arg(exec_os, exec_cpu),
                 static_library_validator_arg(exec_os, exec_cpu),
-            ] + link_wrapper_arg(exec_os, exec_cpu),
+            ],
         )
 
         for (target_os, target_cpu) in targets:

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -210,29 +210,6 @@ def declare_llvm_targets(*, suffix = ""):
         visibility = ["//visibility:public"],
     )
 
-    cc_args(
-        name = "link_wrapper_args",
-        actions = [
-            "@rules_cc//cc/toolchains/actions:link_actions",
-        ],
-        data = [
-            ":clangxx_file",
-            ":dsymutil_file",
-            ":strip_file",
-        ],
-        env = {
-            "LLVM_CLANGXX": "{clangxx}",
-            "LLVM_DSYMUTIL": "{dsymutil}",
-            "LLVM_STRIP": "{strip}",
-        },
-        format = {
-            "clangxx": ":clangxx_file",
-            "dsymutil": ":dsymutil_file",
-            "strip": ":strip_file",
-        },
-        visibility = ["//visibility:public"],
-    )
-
     cc_tool(
         name = "clang",
         src = "bin/clang" + suffix,
@@ -276,6 +253,16 @@ def declare_llvm_targets(*, suffix = ""):
             "bin/lld" + suffix,
             "bin/wasm-ld" + suffix,
         ],
+        env = {
+            "LLVM_CLANGXX": "{clangxx}",
+            "LLVM_DSYMUTIL": "{dsymutil}",
+            "LLVM_STRIP": "{strip}",
+        },
+        format = {
+            "clangxx": ":clangxx_file",
+            "dsymutil": ":dsymutil_file",
+            "strip": ":strip_file",
+        },
     )
 
     cc_tool(

--- a/toolchain/selects.bzl
+++ b/toolchain/selects.bzl
@@ -43,12 +43,6 @@ def static_library_validator_arg(exec_os, exec_cpu):
     # a singleton tool and this per-toolchain args target can be cleaned up.
     return _tool_repo(exec_os, exec_cpu) + ":static_library_validator_args"
 
-def link_wrapper_arg(exec_os, exec_cpu):
-    return select({
-        "@llvm//toolchain:macos_complete": [_tool_repo(exec_os, exec_cpu) + ":link_wrapper_args"],
-        "//conditions:default": [],
-    })
-
 def platform_cc_tool_map(exec_os, exec_cpu):
     tool_repo = _tool_repo(exec_os, exec_cpu)
 


### PR DESCRIPTION
## Summary

Move the link-wrapper subprocess tool environment from target-config `cc_args` to the exec-config `cc_tool(link-wrapper)` declaration.

This removes the stale `link_wrapper_args` plumbing for both prebuilt and bootstrap toolchains, so `LLVM_CLANGXX`, `LLVM_DSYMUTIL`, and `LLVM_STRIP` are configured with the wrapper action tool instead of the target action configuration.

## Root Cause

`tool_map` evaluates tools in the exec configuration, but `link_wrapper_args` was evaluated through `extra_args` in the target configuration. That made the wrapper itself come from exec config while the clang path it executed came from target config.

For macOS dSYM links, Darwin clang then looked for sibling linker tools next to the target-config clang path, even though the linker files were staged with the exec-config wrapper tool.