### PR TITLE
Move exec tools env onto cc_tool

### DIFF
--- a/e2e/rules_cc/bazel_version.bzl
+++ b/e2e/rules_cc/bazel_version.bzl
@@ -4,6 +4,6 @@ def validate_static_library_compatible():
     if bazel_features.cc.supports_starlarkified_toolchains:
         return []
 
-    # Bazel 8 drops `cc_args(env = ...)` on validate_static_library. Keep this
-    # validator integration coverage on Bazel 9+, where the tool env is propagated.
+    # Bazel 8 does not propagate custom tool env on validate_static_library. Keep
+    # this validator integration coverage on Bazel 9+, where the tool env works.
     return ["@platforms//:incompatible"]

--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -1,6 +1,5 @@
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@llvm_config//:version.bzl", "LLVM_VERSION_MAJOR")
-load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
 load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
 load("//platforms:common.bzl", "SUPPORTED_TARGETS")
@@ -143,12 +142,11 @@ def declare_tool_map(exec_os, exec_cpu):
         capabilities = ["@rules_cc//cc/toolchains/capabilities:supports_pic"],
     )
 
-    cc_args(
-        name = prefix + "/header-parser-args",
-        actions = [
-            "@rules_cc//cc/toolchains/actions:cpp_header_parsing",
-        ],
+    cc_tool(
+        name = prefix + "/header-parser",
+        src = "@llvm//tools/internal:header-parser",
         data = [
+            prefix + "/clang_builtin_headers_include_directory",
             prefix + "/bin/clang++",
         ],
         env = {
@@ -157,15 +155,6 @@ def declare_tool_map(exec_os, exec_cpu):
         format = {
             "clangxx": prefix + "/bin/clang++",
         },
-    )
-
-    cc_tool(
-        name = prefix + "/header-parser",
-        src = "@llvm//tools/internal:header-parser",
-        data = [
-            prefix + "/clang_builtin_headers_include_directory",
-            prefix + "/bin/clang++",
-        ],
     )
 
     bootstrap_binary(
@@ -186,11 +175,9 @@ def declare_tool_map(exec_os, exec_cpu):
         actual = "@llvm-project//llvm:llvm.stripped",
     )
 
-    cc_args(
-        name = prefix + "/static-library-validator-args",
-        actions = [
-            "@rules_cc//cc/toolchains/actions:validate_static_library",
-        ],
+    cc_tool(
+        name = prefix + "/static-library-validator",
+        src = "@llvm//tools/internal:static-library-validator",
         data = [
             prefix + "/bin/c++filt",
             prefix + "/bin/llvm-nm",
@@ -203,15 +190,6 @@ def declare_tool_map(exec_os, exec_cpu):
             "cxxfilt": prefix + "/bin/c++filt",
             "llvm_nm": prefix + "/bin/llvm-nm",
         },
-    )
-
-    cc_tool(
-        name = prefix + "/static-library-validator",
-        src = "@llvm//tools/internal:static-library-validator",
-        data = [
-            prefix + "/bin/c++filt",
-            prefix + "/bin/llvm-nm",
-        ],
     )
 
     bootstrap_binary(
@@ -375,10 +353,6 @@ def declare_toolchains(*, execs = None, targets = SUPPORTED_TARGETS):
                 "@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_apple_setting": ":{}_{}/tools_with_libtool_for_runtime".format(exec_os, exec_cpu),
                 "//conditions:default": ":{}_{}/default_tools_for_runtime".format(exec_os, exec_cpu),
             }),
-            extra_args = [
-                ":{}_{}/header-parser-args".format(exec_os, exec_cpu),
-                ":{}_{}/static-library-validator-args".format(exec_os, exec_cpu),
-            ],
         )
 
         for (target_os, target_cpu) in targets:

--- a/toolchain/declare_toolchains.bzl
+++ b/toolchain/declare_toolchains.bzl
@@ -1,5 +1,5 @@
 load("//platforms:common.bzl", "SUPPORTED_EXECS", "SUPPORTED_TARGETS")
-load("//toolchain:selects.bzl", "header_parser_arg", "platform_cc_tool_map", "platform_module_map", "resource_dir_arg", "static_library_validator_arg")
+load("//toolchain:selects.bzl", "platform_cc_tool_map", "platform_module_map", "resource_dir_arg")
 load(":cc_toolchain.bzl", "cc_toolchain")
 
 def declare_toolchains(*, execs = SUPPORTED_EXECS, targets = SUPPORTED_TARGETS):
@@ -21,8 +21,6 @@ def declare_toolchains(*, execs = SUPPORTED_EXECS, targets = SUPPORTED_TARGETS):
             module_map = platform_module_map(exec_os, exec_cpu),
             extra_args = [
                 resource_dir_arg(exec_os, exec_cpu),
-                header_parser_arg(exec_os, exec_cpu),
-                static_library_validator_arg(exec_os, exec_cpu),
             ],
         )
 

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -35,12 +35,11 @@ def declare_llvm_targets(*, suffix = ""):
         srcs = ["bin/llvm-strip" + suffix],
     )
 
-    cc_args(
-        name = "header_parser_args",
-        actions = [
-            "@rules_cc//cc/toolchains/actions:cpp_header_parsing",
-        ],
+    cc_tool(
+        name = "header_parser",
+        src = "@llvm//tools/internal:header-parser",
         data = [
+            ":builtin_resource_dir",
             ":clangxx_file",
         ],
         env = {
@@ -49,16 +48,6 @@ def declare_llvm_targets(*, suffix = ""):
         format = {
             "clangxx": ":clangxx_file",
         },
-        visibility = ["//visibility:public"],
-    )
-
-    cc_tool(
-        name = "header_parser",
-        src = "@llvm//tools/internal:header-parser",
-        data = [
-            ":builtin_resource_dir",
-            ":clangxx_file",
-        ],
         allowlist_include_directories = [":builtin_resource_dir"],
     )
 
@@ -88,43 +77,21 @@ def declare_llvm_targets(*, suffix = ""):
         visibility = ["//visibility:public"],
     )
 
-    native.filegroup(
-        name = "cxxfilt_file",
-        srcs = ["bin/c++filt" + suffix],
-    )
-
-    native.filegroup(
-        name = "llvm_nm_file",
-        srcs = ["bin/llvm-nm" + suffix],
-    )
-
-    cc_args(
-        name = "static_library_validator_args",
-        actions = [
-            "@rules_cc//cc/toolchains/actions:validate_static_library",
-        ],
+    cc_tool(
+        name = "static_library_validator",
+        src = "@llvm//tools/internal:static-library-validator",
         data = [
-            ":cxxfilt_file",
-            ":llvm_nm_file",
+            "bin/c++filt" + suffix,
+            "bin/llvm-nm" + suffix,
         ],
         env = {
             "LLVM_CXXFILT": "{cxxfilt}",
             "LLVM_NM": "{llvm_nm}",
         },
         format = {
-            "cxxfilt": ":cxxfilt_file",
-            "llvm_nm": ":llvm_nm_file",
+            "cxxfilt": "bin/c++filt" + suffix,
+            "llvm_nm": "bin/llvm-nm" + suffix,
         },
-        visibility = ["//visibility:public"],
-    )
-
-    cc_tool(
-        name = "static_library_validator",
-        src = "@llvm//tools/internal:static-library-validator",
-        data = [
-            ":cxxfilt_file",
-            ":llvm_nm_file",
-        ],
     )
 
     BASE_TOOLS = {
@@ -299,8 +266,8 @@ def declare_llvm_targets(*, suffix = ""):
             ],
             "//conditions:default": [],
         }) + [
-            ":cxxfilt_file",
-            ":llvm_nm_file",
+            "bin/c++filt" + suffix,
+            "bin/llvm-nm" + suffix,
         ],
     )
 

--- a/toolchain/selects.bzl
+++ b/toolchain/selects.bzl
@@ -33,16 +33,6 @@ def platform_module_map(exec_os, exec_cpu):
 def resource_dir_arg(exec_os, exec_cpu):
     return _tool_repo(exec_os, exec_cpu) + ":compile_resource_dir"
 
-def header_parser_arg(exec_os, exec_cpu):
-    # Once rules_cc supports `env` on `cc_tool`, header-parser can become a singleton
-    # tool and this per-toolchain args target can be cleaned up.
-    return _tool_repo(exec_os, exec_cpu) + ":header_parser_args"
-
-def static_library_validator_arg(exec_os, exec_cpu):
-    # Once rules_cc supports `env` on `cc_tool`, static-library-validator can become
-    # a singleton tool and this per-toolchain args target can be cleaned up.
-    return _tool_repo(exec_os, exec_cpu) + ":static_library_validator_args"
-
 def platform_cc_tool_map(exec_os, exec_cpu):
     tool_repo = _tool_repo(exec_os, exec_cpu)
 


### PR DESCRIPTION
## Summary

Move tool-specific environment variables for `header-parser` and `static-library-validator` from target-config `cc_args` targets onto the corresponding `cc_tool` declarations.

This removes the now-stale `header_parser_args` and `static_library_validator_args` plumbing from both prebuilt and bootstrap toolchains. `cc_args` remains only for actual action arguments such as the compile resource directory.

## Why

`rules_cc` now supports `env` on `cc_tool`, so tool subprocess environment belongs with the tool selected through `tool_map`. This also keeps tool env in the exec configuration, matching the link-wrapper cleanup in #587.
