### PR TITLE
Allow building LLVM with ABI-breaking checks

### DIFF
--- a/3rd_party/llvm-project/x.x/patches/llvm-abi-breaking-checks.patch
+++ b/3rd_party/llvm-project/x.x/patches/llvm-abi-breaking-checks.patch
@@ -1,0 +1,41 @@
+diff --git a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+@@ -5,2 +5,2 @@
+-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
++load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
+ load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+@@ -22,2 +22,16 @@
+ licenses(["notice"])
++
++# Enable checks that alter LLVM's C++ ABI. Usage:
++#   bazel build --@llvm-project//llvm:enable_abi_breaking_checks=true @llvm-project//llvm:llvm
++bool_flag(
++    name = "enable_abi_breaking_checks",
++    build_setting_default = False,
++)
++
++config_setting(
++    name = "abi_breaking_checks_enabled",
++    flag_values = {
++        ":enable_abi_breaking_checks": "true",
++    },
++)
+
+@@ -148,8 +162,12 @@
+     substitutions = {
+-        # Define to enable checks that alter the LLVM C++ ABI
+-        "#cmakedefine01 LLVM_ENABLE_ABI_BREAKING_CHECKS": "#define LLVM_ENABLE_ABI_BREAKING_CHECKS 0",
+-
+         # Define to enable reverse iteration of unordered llvm containers
+         "#cmakedefine01 LLVM_ENABLE_REVERSE_ITERATION": "#define LLVM_ENABLE_REVERSE_ITERATION 0",
+-    },
++    } | select({
++        ":abi_breaking_checks_enabled": {
++            "#cmakedefine01 LLVM_ENABLE_ABI_BREAKING_CHECKS": "#define LLVM_ENABLE_ABI_BREAKING_CHECKS 1",
++        },
++        "//conditions:default": {
++            "#cmakedefine01 LLVM_ENABLE_ABI_BREAKING_CHECKS": "#define LLVM_ENABLE_ABI_BREAKING_CHECKS 0",
++        },
++    }),
+     template = "include/llvm/Config/abi-breaking.h.cmake",

--- a/extensions/llvm_source.bzl
+++ b/extensions/llvm_source.bzl
@@ -37,6 +37,7 @@ _LLVM_21_SOURCE_PATCHES = _DEFAULT_SOURCE_PATCHES + [
     "//3rd_party/llvm-project/21.x/patches:llvm-windows-stack-size.patch",
     "//3rd_party/llvm-project/21.x/patches:libcxx-lgamma_r.patch",
     "//3rd_party/llvm-project/21.x/patches:llvm-bazel-blake3-windows-gnu.patch",
+    "//3rd_party/llvm-project/x.x/patches:llvm-abi-breaking-checks.patch",
 ]
 
 _LLVM_22_SOURCE_PATCHES = _DEFAULT_SOURCE_PATCHES + [
@@ -51,6 +52,7 @@ _LLVM_22_SOURCE_PATCHES = _DEFAULT_SOURCE_PATCHES + [
     "//3rd_party/llvm-project/22.x/patches:llvm-windows-stack-size.patch",
     "//3rd_party/llvm-project/22.x/patches:libcxx-lgamma_r.patch",
     "//3rd_party/llvm-project/22.x/patches:llvm-bazel-blake3-windows-gnu.patch",
+    "//3rd_party/llvm-project/x.x/patches:llvm-abi-breaking-checks.patch",
 ]
 
 _LLVM_PATCHES_BY_MAJOR = {


### PR DESCRIPTION
Add the default-off `@llvm-project//llvm:enable_abi_breaking_checks` build setting to LLVM's Bazel overlay. Enabling the setting generates `LLVM_ENABLE_ABI_BREAKING_CHECKS=1`; it does not enable ordinary assertions or change `NDEBUG`.

The downstream source patch corresponds to llvm/llvm-project#203739. The patch runs after the LLVM 21 and LLVM 22 version-specific patches because those patches also modify `utils/bazel/llvm-project-overlay/llvm/BUILD.bazel`.

Validation:

- Applied `llvm-abi-breaking-checks.patch` to cached post-version-patch LLVM 21 and LLVM 22 overlays.
- Verified the generated overlays contain `enable_abi_breaking_checks`, `abi_breaking_checks_enabled`, and `LLVM_ENABLE_ABI_BREAKING_CHECKS=1` with no `-UNDEBUG` or assertion-setting names.
- Ran Buildifier on `extensions/llvm_source.bzl`.
