### PR TITLE
Patch llvm_configure as reproducible

### DIFF
--- a/3rd_party/llvm-project/x.x/patches/llvm-configure-reproducible.patch
+++ b/3rd_party/llvm-project/x.x/patches/llvm-configure-reproducible.patch
@@ -1,0 +1,16 @@
+diff --git a/utils/bazel/configure.bzl b/utils/bazel/configure.bzl
+--- a/utils/bazel/configure.bzl
++++ b/utils/bazel/configure.bzl
+@@ -198,10 +198,10 @@ def _llvm_configure_impl(repository_ctx):
+         executable = False,
+     )
+ 
++    return repository_ctx.repo_metadata(reproducible = True)
++
+ llvm_configure = repository_rule(
+     implementation = _llvm_configure_impl,
+-    local = True,
+-    configure = True,
+     attrs = {
+         "targets": attr.string_list(default = DEFAULT_TARGETS),
+     },

--- a/extensions/llvm_source.bzl
+++ b/extensions/llvm_source.bzl
@@ -21,6 +21,7 @@ _DEFAULT_SOURCE_PATCHES = [
     "//3rd_party/llvm-project/x.x/patches:lit_test_stub.patch",
     "//3rd_party/llvm-project/x.x/patches:pfm-rules-cc-load.patch",
     "//3rd_party/llvm-project/x.x/patches:clang-hardlink-filenames.patch",
+    "//3rd_party/llvm-project/x.x/patches:llvm-configure-reproducible.patch",
 ]
 
 _LLVM_21_SOURCE_PATCHES = _DEFAULT_SOURCE_PATCHES + [


### PR DESCRIPTION
## Summary

- add `llvm-configure-reproducible.patch` to `_DEFAULT_SOURCE_PATCHES`
- make `llvm_configure` return `repo_metadata(reproducible = True)`
- remove the stale `local = True` and `configure = True` classifications

## Why

`llvm_configure` originally searched `PATH` for Python and executed the checked-in overlay script with the host Python interpreter. Those host dependencies justified `local = True` and `configure = True` when the rule was introduced.

LLVM commit `744480a2a6b8` rewrote overlay creation in Starlark and removed the host Python lookup and process execution. The current implementation reads `@llvm-raw` and its checked-in Bazel overlay, reads checked-in CMake files, and creates repository output files and symlinks. It does not read environment variables, inspect `PATH`, or execute host tools.

Marking the result reproducible lets Bazel cache and reuse the configured repository according to its repository inputs. The default source patch applies this behavior to LLVM 21, LLVM 22, and current development sources while the upstream change is reviewed.

## Validation

- `buildifier -mode=check extensions/llvm_source.bzl ~/llvm-project/utils/bazel/configure.bzl`
- patch application against `llvmorg-21.1.0`, `llvmorg-22.1.0`, and LLVM `main`
- `bazel mod deps`
- `git diff --check` in both repositories
