### PR TITLE
Support GCC 8 libstdc++

### DIFF
--- a/3rd_party/gcc/gcc.BUILD.bazel
+++ b/3rd_party/gcc/gcc.BUILD.bazel
@@ -204,10 +204,6 @@ _GCC_LT_12_CXX17_SOURCES = [
     ":libstdcxx_cxx17_memory_resource_cc",
 ]
 
-_GCC_LT_11_CXX17_SOURCES = [
-    "libstdc++-v3/src/c++17/memory_resource.cc",
-]
-
 _GCC_11_SRC_INTERNAL_HEADER_GLOBS = [
     "libstdc++-v3/src/c++17/ryu/*.c",
 ]
@@ -254,6 +250,14 @@ _GCC_STRUCTURED_HEADERS_NEED_EXPERIMENTAL_FS_PATH_ADAPTER = gcc_version_at_least
 
 _GCC_EXPERIMENTAL_FS_PATH_NEEDS_NOEXCEPT_HEADER_PATCH = _GCC_STRUCTURED_HEADERS_NEED_EXPERIMENTAL_FS_PATH_ADAPTER
 
+_GCC_9_STRUCTURED_HEADER_GLOBS = [
+    "libstdc++-v3/include/pstl/**",
+]
+
+_GCC_LT_10_STRUCTURED_HEADER_GLOBS = [
+    "libstdc++-v3/include/profile/**",
+]
+
 _GCC_9_CXX17_FS_DIR_SOURCES = [
     "libstdc++-v3/src/c++17/cow-fs_dir.cc",
     "libstdc++-v3/src/c++17/fs_dir.cc",
@@ -272,6 +276,34 @@ _GCC_LT_11_CXX17_COW_STRING_SOURCES = [
 _GCC_11_CXX17_COW_STRING_SOURCES = [
     ":libstdcxx_cxx17_cow_string_inst_cc",
     ":libstdcxx_cxx17_cow_string_inst_inc",
+]
+
+_GCC_9_CXX17_SOURCES = _GCC_9_CXX17_FS_DIR_SOURCES + _GCC_9_CXX17_FS_PATH_SOURCES + [
+    "libstdc++-v3/src/c++17/cow-fs_ops.cc",
+    "libstdc++-v3/src/c++17/fs_ops.cc",
+    "libstdc++-v3/src/c++17/ostream-inst.cc",
+] + (_GCC_11_CXX17_COW_STRING_SOURCES if gcc_version_at_least_for(GCC_VERSION, "11.0.0") else _GCC_LT_11_CXX17_COW_STRING_SOURCES) + [
+    ":libstdcxx_cxx17_string_inst_cc",
+]
+
+_GCC_8_FILESYSTEM_STD_SOURCES = [
+    "libstdc++-v3/src/filesystem/cow-std-dir.cc",
+    "libstdc++-v3/src/filesystem/cow-std-ops.cc",
+    "libstdc++-v3/src/filesystem/cow-std-path.cc",
+    "libstdc++-v3/src/filesystem/std-dir.cc",
+    "libstdc++-v3/src/filesystem/std-ops.cc",
+    "libstdc++-v3/src/filesystem/std-path.cc",
+]
+
+_GCC_9_LIBRARY_HDRS = [
+    ":libstdcxx_cxx17_string_inst_cc",
+]
+
+_GCC_9_STD_HEADERS = [
+    "libstdc++-v3/include/std/bit",
+    "libstdc++-v3/include/std/execution",
+    "libstdc++-v3/include/std/memory_resource",
+    "libstdc++-v3/include/std/version",
 ]
 
 _GCC_9_LIBSUPCXX_PRIVATE_HEADERS = [
@@ -389,7 +421,6 @@ filegroup(
         "libstdc++-v3/include/std/any",
         "libstdc++-v3/include/std/array",
         "libstdc++-v3/include/std/atomic",
-        "libstdc++-v3/include/std/bit",
         "libstdc++-v3/include/std/bitset",
         "libstdc++-v3/include/std/charconv",
         "libstdc++-v3/include/std/chrono",
@@ -397,7 +428,6 @@ filegroup(
         "libstdc++-v3/include/std/complex",
         "libstdc++-v3/include/std/condition_variable",
         "libstdc++-v3/include/std/deque",
-        "libstdc++-v3/include/std/execution",
         "libstdc++-v3/include/std/filesystem",
         "libstdc++-v3/include/std/forward_list",
         "libstdc++-v3/include/std/fstream",
@@ -414,7 +444,6 @@ filegroup(
         "libstdc++-v3/include/std/locale",
         "libstdc++-v3/include/std/map",
         "libstdc++-v3/include/std/memory",
-        "libstdc++-v3/include/std/memory_resource",
         "libstdc++-v3/include/std/mutex",
         "libstdc++-v3/include/std/numeric",
         "libstdc++-v3/include/std/optional",
@@ -443,8 +472,7 @@ filegroup(
         "libstdc++-v3/include/std/valarray",
         "libstdc++-v3/include/std/variant",
         "libstdc++-v3/include/std/vector",
-        "libstdc++-v3/include/std/version",
-    ] + (_GCC_10_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "10.0.0") else []) + (_GCC_11_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "11.0.0") else []) + (_GCC_12_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "12.0.0") else []) + (_GCC_13_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "13.0.0") else []) + (_GCC_14_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "14.0.0") else []) + (_GCC_15_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "15.0.0") else []) + (_GCC_16_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "16.0.0") else []),
+    ] + (_GCC_9_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "9.0.0") else []) + (_GCC_10_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "10.0.0") else []) + (_GCC_11_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "11.0.0") else []) + (_GCC_12_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "12.0.0") else []) + (_GCC_13_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "13.0.0") else []) + (_GCC_14_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "14.0.0") else []) + (_GCC_15_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "15.0.0") else []) + (_GCC_16_STD_HEADERS if gcc_version_at_least_for(GCC_VERSION, "16.0.0") else []),
 )
 
 filegroup(
@@ -504,10 +532,9 @@ filegroup(
             "libstdc++-v3/include/experimental/**",
             "libstdc++-v3/include/ext/**",
             "libstdc++-v3/include/parallel/**",
-            "libstdc++-v3/include/pstl/**",
             "libstdc++-v3/include/tr1/**",
             "libstdc++-v3/include/tr2/**",
-        ],
+        ] + (_GCC_9_STRUCTURED_HEADER_GLOBS if gcc_version_at_least_for(GCC_VERSION, "9.0.0") else []) + (_GCC_LT_10_STRUCTURED_HEADER_GLOBS if not gcc_version_at_least_for(GCC_VERSION, "10.0.0") else []),
         exclude = [
             "**/Makefile.*",
             "**/.editorconfig",
@@ -1377,13 +1404,7 @@ filegroup(
 
 filegroup(
     name = "libstdcxx_cxx17_sources",
-    srcs = _GCC_9_CXX17_FS_DIR_SOURCES + _GCC_9_CXX17_FS_PATH_SOURCES + [
-        "libstdc++-v3/src/c++17/cow-fs_ops.cc",
-        "libstdc++-v3/src/c++17/fs_ops.cc",
-        "libstdc++-v3/src/c++17/ostream-inst.cc",
-    ] + (_GCC_11_CXX17_COW_STRING_SOURCES if gcc_version_at_least_for(GCC_VERSION, "11.0.0") else _GCC_LT_11_CXX17_COW_STRING_SOURCES) + [
-        ":libstdcxx_cxx17_string_inst_cc",
-    ] + (_GCC_11_CXX17_SOURCES if gcc_version_at_least_for(GCC_VERSION, "11.0.0") else []) + (_GCC_12_CXX17_SOURCES if gcc_version_at_least_for(GCC_VERSION, "12.0.0") else (_GCC_LT_12_CXX17_SOURCES if gcc_version_at_least_for(GCC_VERSION, "11.0.0") else _GCC_LT_11_CXX17_SOURCES)),
+    srcs = (_GCC_9_CXX17_SOURCES if gcc_version_at_least_for(GCC_VERSION, "9.0.0") else []) + (_GCC_11_CXX17_SOURCES if gcc_version_at_least_for(GCC_VERSION, "11.0.0") else []) + (_GCC_12_CXX17_SOURCES if gcc_version_at_least_for(GCC_VERSION, "12.0.0") else (_GCC_LT_12_CXX17_SOURCES if gcc_version_at_least_for(GCC_VERSION, "9.0.0") else [])),
 )
 
 filegroup(
@@ -1419,7 +1440,7 @@ filegroup(
         "libstdc++-v3/src/filesystem/dir.cc",
         "libstdc++-v3/src/filesystem/ops.cc",
         "libstdc++-v3/src/filesystem/path.cc",
-    ],
+    ] + (_GCC_8_FILESYSTEM_STD_SOURCES if not gcc_version_at_least_for(GCC_VERSION, "9.0.0") else []),
 )
 
 LIBSTDCXX_LIBRARY_INCLUDES = [
@@ -1440,8 +1461,7 @@ LIBSTDCXX_LIBRARY_INCLUDES = [
 
 # Shared private headers for the libstdc++ library objects. Public installed
 # headers come through the generated build_headers tree instead.
-LIBSTDCXX_LIBRARY_HDRS = [
-    ":libstdcxx_cxx17_string_inst_cc",
+LIBSTDCXX_LIBRARY_HDRS = (_GCC_9_LIBRARY_HDRS if gcc_version_at_least_for(GCC_VERSION, "9.0.0") else []) + [
     ":libsupcxx_headers",
     ":libstdcxx_src_internal_headers",
 ] + (_GCC_LT_13_LIBRARY_HDRS if not gcc_version_at_least_for(GCC_VERSION, "13.0.0") else [])

--- a/3rd_party/gcc/libstdcxx/acinclude.m4.bzl
+++ b/3rd_party/gcc/libstdcxx/acinclude.m4.bzl
@@ -4,8 +4,6 @@
 
 load(
     "//3rd_party/gcc:version.bzl",
-    "gcc_version_at_least_for",
-    "gcc_version_less_than_for",
     "libstdcxx_has_alignas_init_priority_checks",
     "libstdcxx_has_arc4random_getentropy_checks",
     "libstdcxx_has_atomic_builtins_define",
@@ -13,9 +11,11 @@ load(
     "libstdcxx_has_cxx11_no_sleep_define",
     "libstdcxx_has_debugging_checks",
     "libstdcxx_has_decl_strnlen_check",
+    "libstdcxx_has_dev_random_policy",
     "libstdcxx_has_filesystem_chdir_chmod_getcwd_mkdir_checks",
     "libstdcxx_has_filesystem_copy_file_range_check",
     "libstdcxx_has_filesystem_dirfd_checks",
+    "libstdcxx_has_filesystem_extra_posix_checks",
     "libstdcxx_has_filesystem_openat_check",
     "libstdcxx_has_fseeko_ftello_check",
     "libstdcxx_has_int128_float128_checks",
@@ -24,6 +24,7 @@ load(
     "libstdcxx_has_no_sleep_policy",
     "libstdcxx_has_posix_semaphore_check",
     "libstdcxx_has_pthread_clock_checks",
+    "libstdcxx_has_sockatmark_wfopen_checks",
     "libstdcxx_has_stdio_locking_checks",
     "libstdcxx_has_struct_tm_tm_zone_check",
     "libstdcxx_has_system_error_check",
@@ -1217,7 +1218,7 @@ int main() { fchmodat(AT_FDCWD, "", 0, AT_SYMLINK_NOFOLLOW); return 0; }
         ),
         function_link_check("_GLIBCXX_USE_SENDFILE", "sys/sendfile.h", "sendfile(1, 2, (off_t *)0, sizeof 1)", compile_flags = CXX_FILESYSTEM_FLAGS),
     ]
-    if gcc_version_at_least_for(gcc_version, "9.0.0"):
+    if libstdcxx_has_filesystem_extra_posix_checks(gcc_version):
         checks.extend([
             link_check(
                 name = "_GLIBCXX_USE_UTIME",
@@ -1508,9 +1509,9 @@ int main() { return __cxa_thread_atexit_impl((void (*)(void *))0, (void *)0, (vo
             function_link_check("HAVE_ARC4RANDOM", "stdlib.h", "unsigned x = arc4random()"),
             function_link_check("HAVE_GETENTROPY", "unistd.h", "char buf[8]; getentropy(buf, sizeof(buf))"),
         ])
-    if gcc_version_at_least_for(gcc_version, "9.0.0"):
+    if libstdcxx_has_sockatmark_wfopen_checks(gcc_version):
         checks.append(function_link_check("HAVE_SOCKATMARK", "sys/socket.h", "int i = sockatmark(0)"))
-    if gcc_version_at_least_for(gcc_version, "9.0.0"):
+    if libstdcxx_has_sockatmark_wfopen_checks(gcc_version):
         checks.append(function_link_check("HAVE__WFOPEN", "wchar.h", 'FILE *f = _wfopen(L"", L"r")'))
     return checks
 
@@ -1548,7 +1549,7 @@ def glibcxx_check_system_error(gcc_version):
     ]
 
 def glibcxx_random_policy(gcc_version):
-    if gcc_version_less_than_for(gcc_version, "9.0.0"):
+    if not libstdcxx_has_dev_random_policy(gcc_version):
         return [
             policy_define("_GLIBCXX_USE_RANDOM_TR1"),
         ]

--- a/3rd_party/gcc/libstdcxx/crossconfig.m4.bzl
+++ b/3rd_party/gcc/libstdcxx/crossconfig.m4.bzl
@@ -2,7 +2,7 @@
 # libstdc++-v3/crossconfig.m4. Only the Linux GNU-relevant branch is active in
 # this Bazel port; other target branches remain documented as unsupported.
 
-load("//3rd_party/gcc:version.bzl", "gcc_version_at_least_for")
+load("//3rd_party/gcc:version.bzl", "libstdcxx_has_dev_random_policy")
 load("//3rd_party/gcc/libstdcxx/autoconf:checks.bzl", "policy_define")
 load(
     ":gcc_config_checks.bzl",
@@ -21,7 +21,7 @@ def glibcxx_crossconfig_linux_gnu(gcc_version):
     # *-gnu*, *-kfreebsd*-gnu, *-cygwin*, and *-solaris*. Only Linux GNU is
     # active in this Bazel port; cygwin/solaris and non-glibc targets are out
     # of scope.
-    if gcc_version_at_least_for(gcc_version, "9.0.0"):
+    if libstdcxx_has_dev_random_policy(gcc_version):
         random_policy = [
             # crossconfig.m4 hardcodes the same GLIBCXX_CHECK_DEV_RANDOM
             # feature pair for Linux-family targets.

--- a/3rd_party/gcc/libstdcxx/docs/autoconf.README.md
+++ b/3rd_party/gcc/libstdcxx/docs/autoconf.README.md
@@ -126,9 +126,9 @@ section flags, lock-free atomic word support, decimal floating-point support,
 int128 support, and gthreads support. The active Linux GNU behavior is modeled,
 with some answers represented as target policy where GCC's result is
 target-derived. Decimal floating point and GCC 11 int128 support are compile
-probes. Float128 remains deferred. The gthreads availability and
-pthread read/write lock checks compile against the generated `bits/gthr.h`
-overlay so they follow the staged header context used by this Bazel port.
+probes. Float128 remains deferred. The gthreads availability and pthread
+read/write lock checks compile against the generated `bits/gthr.h` overlay so
+they follow the staged header context used by this Bazel port.
 
 `GLIBCXX_CHECK_LINKER_FEATURES`, `GLIBCXX_ENABLE_SYMVERS`,
 `GLIBCXX_CHECK_EXCEPTION_PTR_SYMVER`, `GLIBCXX_DEFAULT_ABI`,
@@ -149,16 +149,16 @@ The Bazel port models the Linux GNU dynamic libstdc++ path.
 groups from `acinclude.m4` and `linkage.m4`. The Bazel port represents these
 as grouped link probes in `linkage.m4.bzl`.
 
-GCC 9+ `GLIBCXX_CHECK_DEV_RANDOM`, GCC 12+ `GLIBCXX_CHECK_ARC4RANDOM`, GCC 12+
-`GLIBCXX_CHECK_GETENTROPY`, `GLIBCXX_CHECK_FILESYSTEM_DEPS`,
-GCC 14+ `GLIBCXX_CHECK_TEXT_ENCODING`, GCC 16+ `GLIBCXX_CHECK_DEBUGGING`,
-GCC 16+ `GLIBCXX_CHECK_STDIO_LOCKING`, GCC 15+ `GLIBCXX_STRUCT_TM_TM_ZONE`,
-GCC 13+ `GLIBCXX_ZONEINFO_DIR`, GCC 13+
+GCC 8 `GLIBCXX_CHECK_RANDOM_TR1`, GCC 9+ `GLIBCXX_CHECK_DEV_RANDOM`, GCC 12+
+`GLIBCXX_CHECK_ARC4RANDOM`, GCC 12+ `GLIBCXX_CHECK_GETENTROPY`,
+`GLIBCXX_CHECK_FILESYSTEM_DEPS`, GCC 14+ `GLIBCXX_CHECK_TEXT_ENCODING`, GCC 16+
+`GLIBCXX_CHECK_DEBUGGING`, GCC 16+ `GLIBCXX_CHECK_STDIO_LOCKING`, GCC 15+
+`GLIBCXX_STRUCT_TM_TM_ZONE`, GCC 13+ `GLIBCXX_ZONEINFO_DIR`, GCC 13+
 `GLIBCXX_CHECK_ALIGNAS_CACHELINE`, GCC 13+ `GLIBCXX_CHECK_INIT_PRIORITY`,
-`GLIBCXX_CHECK_SYSTEM_ERROR`, `GLIBCXX_CHECK_X86_RDRAND`,
+GCC 8 `GLIBCXX_CHECK_SYSTEM_ERROR`, `GLIBCXX_CHECK_X86_RDRAND`,
 `GLIBCXX_CHECK_X86_RDSEED`, and `GLIBCXX_CHECK_SIZE_T_MANGLING` cover runtime
 library details after the core libc checks. The active Linux GNU behavior is
-modeled as probes or policy. `GLIBCXX_CHECK_DEV_RANDOM` is policy-modeled
+modeled as probes or policy. The random-device checks are policy-modeled
 rather than probed because GCC's native check reads the execution host's
 `/dev/random` and `/dev/urandom`, while the supported Bazel target decision is
 Linux GNU and GCC's cross configuration hardcodes that answer for Linux-family
@@ -180,12 +180,11 @@ reference-count ABI even when compare-and-swap builtins exist.
 `GLIBCXX_ENABLE_FLOAT128`, `GLIBCXX_ENABLE_FULLY_DYNAMIC_STRING`,
 `GLIBCXX_ENABLE_CSTDIO`'s `stdio_pure` mode, `GLIBCXX_ENABLE_ALLOCATOR`'s
 `malloc` mode, NLS, and GCC 13+ `GLIBCXX_EMERGENCY_EH_ALLOC` are currently
-fixed or
-disabled policies. They should become explicit private Bazel settings only if
-the port exposes the corresponding GCC variant. `GLIBCXX_ENABLE_DECIMAL_FLOAT`
-is already represented by a compile probe and is not a deferred knob. Float128
-remains fixed disabled until the probe result and `float128.ver` version-script
-input can be modeled together.
+fixed or disabled policies. They should become explicit private Bazel settings
+only if the port exposes the corresponding GCC variant.
+`GLIBCXX_ENABLE_DECIMAL_FLOAT` is already represented by a compile probe and is
+not a deferred knob. Float128 remains fixed disabled until the probe result and
+`float128.ver` version-script input can be modeled together.
 
 ## Audited Policy And Defaults
 

--- a/3rd_party/gcc/libstdcxx/docs/autoconf.checks.md
+++ b/3rd_party/gcc/libstdcxx/docs/autoconf.checks.md
@@ -48,6 +48,7 @@ Status meanings are defined in `AGENTS.md`.
 - [x] `GLIBCXX_CHECK_PTHREAD_COND_CLOCKWAIT` - pthread cond clockwait probe.
 - [x] `GLIBCXX_CHECK_PTHREAD_MUTEX_CLOCKLOCK` - pthread mutex clocklock probe.
 - [x] `GLIBCXX_CHECK_PTHREAD_RWLOCK_CLOCKLOCK` - pthread rwlock clocklock probe.
+- [x] `GLIBCXX_CHECK_RANDOM_TR1` - GCC 8 TR1 random-device policy.
 - [x] `GLIBCXX_CHECK_SC_NPROCESSORS_ONLN` - `sysconf` processor-count probe.
 - [x] `GLIBCXX_CHECK_SC_NPROC_ONLN` - `sysconf` processor-count probe.
 - [x] `GLIBCXX_CHECK_SDT_H` - systemtap header probe.
@@ -58,7 +59,7 @@ Status meanings are defined in `AGENTS.md`.
 - [x] `GLIBCXX_CHECK_STDLIB_DECL_AND_LINKAGE_2` - `linkage.m4` stdlib helper.
 - [x] `GLIBCXX_CHECK_STDLIB_DECL_AND_LINKAGE_3` - stdlib helper represented by stdlib support probes.
 - [x] `GLIBCXX_CHECK_STDLIB_SUPPORT` - native stdlib support probe group.
-- [x] `GLIBCXX_CHECK_SYSTEM_ERROR` - Linux errno availability policy for legacy configure flows.
+- [x] `GLIBCXX_CHECK_SYSTEM_ERROR` - GCC 8 Linux errno availability policy.
 - [x] `GLIBCXX_CHECK_S_ISREG_OR_S_IFREG` - `S_ISREG`/`S_IFREG` probe.
 - [x] `GLIBCXX_CHECK_TEXT_ENCODING` - GCC 14+ text encoding support probes.
 - [x] `GLIBCXX_CHECK_TMPNAM` - `tmpnam` probe.

--- a/3rd_party/gcc/libstdcxx/docs/autoconf.usage.md
+++ b/3rd_party/gcc/libstdcxx/docs/autoconf.usage.md
@@ -58,6 +58,7 @@ Status meanings are defined in `AGENTS.md`.
 - [x] `GLIBCXX_CHECK_MATH_SUPPORT` - native math probes are modeled; `modeled`.
 - [x] `GLIBCXX_CHECK_STDLIB_SUPPORT` - native stdlib probes are modeled; `modeled`.
 - [x] `GLIBCXX_CHECK_DEV_RANDOM` - Linux random-device policy is modeled; `modeled`.
+- [x] `GLIBCXX_CHECK_RANDOM_TR1` - GCC 8 TR1 random-device policy is modeled; `modeled`.
 - [x] `GLIBCXX_CHECK_ARC4RANDOM` - GCC 12+ `arc4random` probe is modeled; `modeled`.
 - [x] `GLIBCXX_CHECK_GETENTROPY` - GCC 12+ `getentropy` probe is modeled; `modeled`.
 - [x] `GLIBCXX_CHECK_FILESYSTEM_DEPS` - filesystem probes are modeled; `modeled`.
@@ -99,7 +100,7 @@ Status meanings are defined in `AGENTS.md`.
 - [x] `GLIBCXX_CHECK_STDLIB_DECL_AND_LINKAGE_1` - represented by stdlib support probes; `modeled`.
 - [x] `GLIBCXX_CHECK_STDLIB_DECL_AND_LINKAGE_2` - represented by stdlib support probes; `modeled`.
 - [x] `GLIBCXX_CHECK_STDLIB_DECL_AND_LINKAGE_3` - represented by stdlib support probes; `modeled`.
-- [x] `GLIBCXX_CHECK_SYSTEM_ERROR` - Linux errno availability is modeled; `modeled`.
+- [x] `GLIBCXX_CHECK_SYSTEM_ERROR` - GCC 8 Linux errno availability is modeled; `modeled`.
 
 ## Build Setting Later
 

--- a/3rd_party/gcc/libstdcxx/docs/config_define_status.txt
+++ b/3rd_party/gcc/libstdcxx/docs/config_define_status.txt
@@ -11,7 +11,8 @@
 # intentionally-defaulted: deliberately left undefined for supported targets.
 # unsupported-feature: optional libstdc++ feature not built by this port today.
 # unsupported-target: target family not supported by this libstdc++ port today.
-# Optional third column: version condition for the currently supported GCC versions.
+# Optional third column: version condition such as gcc_ge_10, gcc_ge_12_4,
+# gcc_ge_11_lt_16, gcc_ge_12_4_lt_13, gcc_lt_8_3, or comma-separated ORs.
 HAVE_ACOSF probe-modeled
 HAVE_ACOSL probe-modeled
 HAVE_ALIGNED_ALLOC probe-modeled
@@ -23,7 +24,7 @@ HAVE_ATAN2F probe-modeled
 HAVE_ATAN2L probe-modeled
 HAVE_ATANF probe-modeled
 HAVE_ATANL probe-modeled
-HAVE_ATOMIC_LOCK_POLICY target-derived
+HAVE_ATOMIC_LOCK_POLICY target-derived gcc_ge_9
 HAVE_AT_QUICK_EXIT probe-modeled
 HAVE___CXA_THREAD_ATEXIT probe-modeled
 HAVE___CXA_THREAD_ATEXIT_IMPL probe-modeled
@@ -92,7 +93,7 @@ HAVE_ISWBLANK probe-modeled
 HAVE_LC_MESSAGES probe-modeled
 HAVE_LDEXPF probe-modeled
 HAVE_LDEXPL probe-modeled
-HAVE_LINK probe-modeled
+HAVE_LINK probe-modeled gcc_ge_9
 HAVE_LINUX_FUTEX probe-modeled
 HAVE_LOG10F probe-modeled
 HAVE_LOG10L probe-modeled
@@ -115,7 +116,7 @@ HAVE_POWF probe-modeled
 HAVE_POWL probe-modeled
 HAVE_QFPCLASS probe-modeled
 HAVE_QUICK_EXIT probe-modeled
-HAVE_READLINK probe-modeled
+HAVE_READLINK probe-modeled gcc_ge_9
 HAVE_SECURE_GETENV probe-modeled gcc_ge_11_4
 HAVE_SETENV probe-modeled
 HAVE_SINCOSL probe-modeled
@@ -126,7 +127,7 @@ HAVE_SINHF probe-modeled
 HAVE_SINHL probe-modeled
 HAVE_SINL probe-modeled
 HAVE_SLEEP probe-modeled
-HAVE_SOCKATMARK probe-modeled
+HAVE_SOCKATMARK probe-modeled gcc_ge_9
 HAVE_SQRTF probe-modeled
 HAVE_SQRTL probe-modeled
 HAVE_STACKTRACE unsupported-feature gcc_ge_12
@@ -137,7 +138,7 @@ HAVE_STRTOF probe-modeled
 HAVE_STRTOLD probe-modeled
 HAVE_STRUCT_DIRENT_D_TYPE probe-modeled
 HAVE_STRXFRM_L probe-modeled
-HAVE_SYMLINK probe-modeled
+HAVE_SYMLINK probe-modeled gcc_ge_9
 HAVE_SYMVER_SYMBOL_RENAMING_RUNTIME_SUPPORT policy-modeled
 HAVE_SYS_SDT_H header-probe
 HAVE_SYS_STAT_H header-probe gcc_ge_16
@@ -148,9 +149,9 @@ HAVE_TANF probe-modeled
 HAVE_TANHF probe-modeled
 HAVE_TANHL probe-modeled
 HAVE_TANL probe-modeled
-HAVE_TIMESPEC_GET probe-modeled
+HAVE_TIMESPEC_GET probe-modeled gcc_ge_9
 HAVE_TLS probe-modeled
-HAVE_TRUNCATE probe-modeled
+HAVE_TRUNCATE probe-modeled gcc_ge_9
 HAVE_UNISTD_H header-probe gcc_ge_16
 HAVE_UNLINKAT probe-modeled gcc_ge_11_5
 HAVE_USELOCALE probe-modeled gcc_ge_11
@@ -163,7 +164,7 @@ HAVE_WCSTOF probe-modeled
 HAVE_WRITEV probe-modeled
 HAVE__ALIGNED_MALLOC probe-modeled
 HAVE__BOOL not-needed
-HAVE__WFOPEN probe-modeled
+HAVE__WFOPEN probe-modeled gcc_ge_9
 HAVE_CC_TLS probe-modeled
 ICONV_CONST intentionally-defaulted
 STRING_WITH_STRINGS not-needed
@@ -226,9 +227,10 @@ _GLIBCXX_USE_CLOCK_MONOTONIC probe-modeled
 _GLIBCXX_USE_CLOCK_REALTIME probe-modeled
 _GLIBCXX_USE_COPY_FILE_RANGE probe-modeled gcc_ge_14
 _GLIBCXX_USE_DECIMAL_FLOAT probe-modeled
-_GLIBCXX_USE_DEV_RANDOM policy-modeled
+_GLIBCXX_USE_DEV_RANDOM policy-modeled gcc_ge_9
 _GLIBCXX_USE_FCHMOD probe-modeled
 _GLIBCXX_USE_FCHMODAT probe-modeled
+_GLIBCXX_USE_FLOAT128 unsupported-feature gcc_lt_8_3
 _GLIBCXX_USE_FSEEKO_FTELLO probe-modeled gcc_ge_13_2
 _GLIBCXX_USE_GETCWD probe-modeled gcc_ge_12_4_lt_13,gcc_ge_13_3
 _GLIBCXX_USE_GETTIMEOFDAY probe-modeled
@@ -238,7 +240,7 @@ _GLIBCXX_USE_INIT_PRIORITY_ATTRIBUTE probe-modeled gcc_ge_13_2
 _GLIBCXX_USE_INT128 probe-modeled gcc_lt_12
 _GLIBCXX_USE_LFS probe-modeled
 _GLIBCXX_USE_LONG_LONG policy-modeled
-_GLIBCXX_USE_LSTAT probe-modeled
+_GLIBCXX_USE_LSTAT probe-modeled gcc_ge_9
 _GLIBCXX_USE_MKDIR probe-modeled gcc_ge_12_4_lt_13,gcc_ge_13_3
 _GLIBCXX_USE_NANOSLEEP probe-modeled
 _GLIBCXX_USE_NLS build-setting-later
@@ -264,7 +266,7 @@ _GLIBCXX_USE_SYSCTL_HW_NCPU unsupported-target
 _GLIBCXX_USE_TMPNAM probe-modeled
 _GLIBCXX_USE_UCHAR_C8RTOMB_MBRTOC8_CXX20 probe-modeled gcc_ge_12
 _GLIBCXX_USE_UCHAR_C8RTOMB_MBRTOC8_FCHAR8_T probe-modeled gcc_ge_12
-_GLIBCXX_USE_UTIME probe-modeled
+_GLIBCXX_USE_UTIME probe-modeled gcc_ge_9
 _GLIBCXX_USE_UTIMENSAT probe-modeled
 _GLIBCXX_USE_WCHAR_T probe-modeled
 _GLIBCXX_USE_WIN32_SLEEP policy-modeled gcc_ge_13

--- a/3rd_party/gcc/libstdcxx/docs/config_macro_status.txt
+++ b/3rd_party/gcc/libstdcxx/docs/config_macro_status.txt
@@ -7,7 +7,9 @@
 # not-needed: configure/build/install/testsuite plumbing replaced by Bazel.
 # unsupported-feature: optional libstdc++ feature not built by this port today.
 # unsupported-target: target family not supported by this libstdc++ port today.
-# Optional third column: version condition for the currently supported GCC versions.
+# Optional third column: version condition such as gcc_ge_10, gcc_ge_11,
+# gcc_ge_11_lt_16, gcc_lt_12, gcc_ge_12, gcc_lt_13, gcc_ge_13, gcc_lt_14,
+# gcc_ge_14, gcc_ge_15, gcc_lt_16, or gcc_ge_16.
 GCC_AC_THREAD_HEADER target-derived
 GCC_AC_THREAD_MODEL target-derived gcc_ge_16
 GCC_BASE_VER not-needed
@@ -26,7 +28,7 @@ GLIBCXX_CHECK_ARC4RANDOM modeled gcc_ge_12
 GLIBCXX_CHECK_C99_TR1 modeled
 GLIBCXX_CHECK_COMPILER_FEATURES modeled
 GLIBCXX_CHECK_DEBUGGING modeled gcc_ge_16
-GLIBCXX_CHECK_DEV_RANDOM modeled
+GLIBCXX_CHECK_DEV_RANDOM modeled gcc_ge_9
 GLIBCXX_CHECK_EXCEPTION_PTR_SYMVER modeled
 GLIBCXX_CHECK_FILEBUF_NATIVE_HANDLES unsupported-target gcc_ge_14
 GLIBCXX_CHECK_FILESYSTEM_DEPS modeled
@@ -55,6 +57,7 @@ GLIBCXX_CHECK_PTHREADS_NUM_PROCESSORS_NP modeled
 GLIBCXX_CHECK_PTHREAD_COND_CLOCKWAIT modeled gcc_ge_10
 GLIBCXX_CHECK_PTHREAD_MUTEX_CLOCKLOCK modeled gcc_ge_10
 GLIBCXX_CHECK_PTHREAD_RWLOCK_CLOCKLOCK modeled gcc_ge_10
+GLIBCXX_CHECK_RANDOM_TR1 modeled gcc_lt_9
 GLIBCXX_CHECK_SC_NPROCESSORS_ONLN modeled
 GLIBCXX_CHECK_SC_NPROC_ONLN modeled
 GLIBCXX_CHECK_SDT_H modeled
@@ -106,7 +109,7 @@ GLIBCXX_ENABLE_INT128_FLOAT128 modeled gcc_lt_12
 GLIBCXX_ENABLE_LIBSTDCXX_DUAL_ABI modeled
 GLIBCXX_ENABLE_LIBSTDCXX_TIME modeled
 GLIBCXX_ENABLE_LIBSTDCXX_VISIBILITY modeled
-GLIBCXX_ENABLE_LOCK_POLICY target-derived
+GLIBCXX_ENABLE_LOCK_POLICY target-derived gcc_ge_9
 GLIBCXX_ENABLE_LONG_LONG modeled
 GLIBCXX_ENABLE_PARALLEL unsupported-feature
 GLIBCXX_ENABLE_PCH not-needed

--- a/3rd_party/gcc/libstdcxx/linkage.m4.bzl
+++ b/3rd_party/gcc/libstdcxx/linkage.m4.bzl
@@ -14,8 +14,8 @@
 
 load(
     "//3rd_party/gcc:version.bzl",
-    "gcc_version_at_least_for",
     "libstdcxx_has_stdlib_secure_getenv_check",
+    "libstdcxx_has_stdlib_timespec_get_check",
 )
 load(
     "//3rd_party/gcc/libstdcxx/autoconf:checks.bzl",
@@ -132,7 +132,7 @@ def gcc_check_stdlib_support(gcc_version):
         function_link_check("HAVE_STRTOF", "stdlib.h", 'float f = strtof("1", (char **)0)'),
         function_link_check("HAVE_STRTOLD", "stdlib.h", 'long double ld = strtold("1", (char **)0)'),
     ]
-    if gcc_version_at_least_for(gcc_version, "9.0.0"):
+    if libstdcxx_has_stdlib_timespec_get_check(gcc_version):
         checks.append(function_link_check("HAVE_TIMESPEC_GET", "time.h", "struct timespec ts; timespec_get(&ts, TIME_UTC)"))
     if libstdcxx_has_stdlib_secure_getenv_check(gcc_version):
         checks.append(function_link_check("HAVE_SECURE_GETENV", "stdlib.h", 'char *p = secure_getenv("PATH")'))

--- a/3rd_party/gcc/libstdcxx/target_config.bzl
+++ b/3rd_party/gcc/libstdcxx/target_config.bzl
@@ -3,7 +3,7 @@
 # fields, compare against configure.host plus configure.ac's *_SRCDIR
 # substitutions for the generated include/source paths.
 
-load("//3rd_party/gcc:version.bzl", "gcc_version_at_least_for")
+load("//3rd_party/gcc:version.bzl", "libstdcxx_has_atomic_lock_policy_define")
 load("//3rd_party/gcc/libstdcxx/autoconf:checks.bzl", "policy_define", "policy_undef")
 
 _SUPPORTED_TARGETS = {
@@ -310,7 +310,7 @@ def libstdcxx_config_h_policy_defines(gcc_version):
                 policy_define("HAVE_SYMVER_SYMBOL_RENAMING_RUNTIME_SUPPORT"),
                 policy_define("HAVE_EXCEPTION_PTR_SINCE_GCC46"),
             ] if _field_value(values, "symver_style") == "gnu" else []) +
-            ([policy_define("HAVE_ATOMIC_LOCK_POLICY")] if gcc_version_at_least_for(gcc_version, "9.0.0") and values["atomic_lock_policy"] else []) +
+            ([policy_define("HAVE_ATOMIC_LOCK_POLICY")] if libstdcxx_has_atomic_lock_policy_define(gcc_version) and values["atomic_lock_policy"] else []) +
             [policy_define("_GLIBCXX_MANGLE_SIZE_T", _field_value(values, "size_t_mangling"))] +
             ([
                 policy_define("_GLIBCXX_PTRDIFF_T_IS_INT"),

--- a/3rd_party/gcc/version.bzl
+++ b/3rd_party/gcc/version.bzl
@@ -29,6 +29,11 @@ GCC_VERSIONS = [
     "9.3.0",
     "9.2.0",
     "9.1.0",
+    "8.5.0",
+    "8.4.0",
+    "8.3.0",
+    "8.2.0",
+    "8.1.0",
 ]
 
 DEFAULT_GCC_VERSION = "17.0.0"
@@ -153,6 +158,26 @@ GCC_RELEASES = {
     "9.5.0": {
         "commit": "7a15b5060a83ea8282323d92043c6152e6a3e22d",
         "sha256": "a41dba755e4cbcb96a984cd2284c37df4ddf0db094a9af3acd4e4647cd416848",
+    },
+    "8.1.0": {
+        "commit": "406c2abec3f998e9064919b22db62f38a7c0e7b9",
+        "sha256": "6f31c32ab844293951fe4f846dcec361ee24424cc416879a96176990a76ad4fe",
+    },
+    "8.2.0": {
+        "commit": "ddeb81e76461fc0075542d436dc962f3cf6fac92",
+        "sha256": "6c91235412ef1c5fc5e4c295f49b7079c879c2db8c64b008202e41f219dad918",
+    },
+    "8.3.0": {
+        "commit": "4c44b708f11eec6fc02456e8577708d01ca92327",
+        "sha256": "9a3d65f2ae7ed56ee601ba04cd8a2563dbb9409e7e98319d94c56d4366c418f0",
+    },
+    "8.4.0": {
+        "commit": "8cd3bffead2ed1d1998c190865694f920fbc93ab",
+        "sha256": "6d02f84e8b40e6b140a008cd261ed9bdd4c05f7df7692ef6d0a84cae37fd2118",
+    },
+    "8.5.0": {
+        "commit": "eafe83f2f20ef0c1e7703c361ba314b44574523c",
+        "sha256": "87bb3018c1523d7fc1d089c69beb93439f3c3675f3af16933d0259682956a151",
     },
 }
 
@@ -356,10 +381,25 @@ def libstdcxx_has_uselocale_check(version):
     return gcc_version_at_least_for(version, "11.0.0")
 
 def libstdcxx_has_system_error_check(version):
-    return (gcc_version_at_least_for(version, "9.0.0") and gcc_version_less_than_for(version, "9.5.0")) or (gcc_version_at_least_for(version, "10.1.0") and gcc_version_less_than_for(version, "10.3.0"))
+    return gcc_version_less_than_for(version, "9.5.0") or (gcc_version_at_least_for(version, "10.1.0") and gcc_version_less_than_for(version, "10.3.0"))
 
 def libstdcxx_has_pthread_clock_checks(version):
     return gcc_version_at_least_for(version, "10.0.0")
 
 def libstdcxx_has_x86_rdseed_check(version):
     return gcc_version_at_least_for(version, "10.0.0")
+
+def libstdcxx_has_dev_random_policy(version):
+    return gcc_version_at_least_for(version, "9.0.0")
+
+def libstdcxx_has_filesystem_extra_posix_checks(version):
+    return gcc_version_at_least_for(version, "9.0.0")
+
+def libstdcxx_has_sockatmark_wfopen_checks(version):
+    return gcc_version_at_least_for(version, "9.0.0")
+
+def libstdcxx_has_stdlib_timespec_get_check(version):
+    return gcc_version_at_least_for(version, "9.0.0")
+
+def libstdcxx_has_atomic_lock_policy_define(version):
+    return gcc_version_at_least_for(version, "9.0.0")


### PR DESCRIPTION
Adds libstdc++ support for GCC 8.x on top of the merged GCC 9 support.\n\nValidation:\n- bazel build --config remote --noshow_progress --color=no --curses=no //internal_tools:buildifier.check\n- bazel build --config remote --noshow_progress --color=no --curses=no //runtimes/libstdcxx/tests:toolchain_dynamic_link_smoke_linux_x86_64_all_versions //runtimes/libstdcxx/tests:toolchain_dynamic_link_smoke_linux_aarch64_all_versions\n\nNotes:\n- GCC 8 does not require libstdc++ source rewrite patches.\n- No GCC 8-specific expand_template rewrites are added.