### PR TITLE
[codex] Support distributed ThinLTO on macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,11 +40,11 @@ common:bootstrap   --@llvm//toolchain:source=bootstrapped
 common:prebuilt  -c opt
 common:prebuilt  --strip=always
 common:prebuilt  --stripopt=--strip-all
-# TODO: Enable Windows ThinLTO unconditionally after a rules_cc release includes Windows ThinLTO support.
-common:prebuilt  --@llvm//toolchain:enable_windows_thin_lto=true
-# Use ThinLTO when available (on Linux), but it doesn't work for Darwin targets, so also enable `flto=thin` as fallback.
+# TODO: Remove is_windows_capable_of_thinlto_feature after a rules_cc release includes Windows distributed ThinLTO support.
+common:prebuilt  --@llvm//toolchain:is_windows_capable_of_thinlto_feature=true
+# TODO: Remove is_macos_capable_of_thinlto_feature after rules_cc and LLVM releases include macOS distributed ThinLTO support.
+common:prebuilt  --@llvm//toolchain:is_macos_capable_of_thinlto_feature=true
 common:prebuilt   --features=thin_lto
-common:prebuilt  --copt=-flto=thin
 common:prebuilt  --copt=-fno-exceptions
 common:prebuilt  --copt=-fno-rtti
 common:prebuilt  --copt=-fomit-frame-pointer

--- a/3rd_party/llvm-project/x.x/patches/lld-macho-thinlto-obj-path.patch
+++ b/3rd_party/llvm-project/x.x/patches/lld-macho-thinlto-obj-path.patch
@@ -1,0 +1,78 @@
+diff --git a/lld/MachO/Config.h b/lld/MachO/Config.h
+index 814ba1016849..84e7cfa2b6ca 100644
+--- a/lld/MachO/Config.h
++++ b/lld/MachO/Config.h
+@@ -169,6 +169,7 @@ struct Configuration {
+   llvm::StringRef mapFile;
+   llvm::StringRef ltoNewPmPasses;
+   llvm::StringRef ltoObjPath;
++  bool ltoObjPathIsFile = false;
+   llvm::StringRef thinLTOJobs;
+   llvm::StringRef umbrella;
+   uint32_t ltoo = 2;
+diff --git a/lld/MachO/Driver.cpp b/lld/MachO/Driver.cpp
+index 973b3f5535cb..697be3f4c023 100644
+--- a/lld/MachO/Driver.cpp
++++ b/lld/MachO/Driver.cpp
+@@ -1928,7 +1928,11 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
+       warn("-umbrella used, but not creating dylib");
+     config->umbrella = arg->getValue();
+   }
+-  config->ltoObjPath = args.getLastArgValue(OPT_object_path_lto);
++  if (const Arg *arg =
++          args.getLastArg(OPT_object_path_lto, OPT_lto_obj_path_eq)) {
++    config->ltoObjPath = arg->getValue();
++    config->ltoObjPathIsFile = arg->getOption().matches(OPT_lto_obj_path_eq);
++  }
+   config->ltoNewPmPasses = args.getLastArgValue(OPT_lto_newpm_passes);
+   config->thinLTOCacheDir = args.getLastArgValue(OPT_cache_path_lto);
+   config->thinLTOCachePolicy = getLTOCachePolicy(args);
+diff --git a/lld/MachO/LTO.cpp b/lld/MachO/LTO.cpp
+index 2c360374ef3c..b1e45bfc8199 100644
+--- a/lld/MachO/LTO.cpp
++++ b/lld/MachO/LTO.cpp
+@@ -234,15 +234,15 @@ std::vector<ObjFile *> BitcodeCompiler::compile() {
+     thinLTOCreateEmptyIndexFiles();
+
+   // In ThinLTO mode, Clang passes a temporary directory in -object_path_lto,
+-  // while the argument is a single file in FullLTO mode.
+-  bool objPathIsDir = true;
+-  if (!config->ltoObjPath.empty()) {
++  // while -object_path_lto specifies a single file in FullLTO mode.
++  // --lto-obj-path always specifies a file.
++  bool objPathIsDir = !config->ltoObjPathIsFile;
++  if (!config->ltoObjPath.empty() && objPathIsDir) {
+     if (std::error_code ec = fs::create_directories(config->ltoObjPath))
+       fatal("cannot create LTO object path " + config->ltoObjPath + ": " +
+             ec.message());
+-
+-    if (!fs::is_directory(config->ltoObjPath)) {
+-      objPathIsDir = false;
++    objPathIsDir = fs::is_directory(config->ltoObjPath);
++    if (!objPathIsDir) {
+       unsigned objCount =
+           count_if(buf, [](const SmallString<0> &b) { return !b.empty(); });
+       if (objCount > 1)
+@@ -258,6 +258,8 @@ std::vector<ObjFile *> BitcodeCompiler::compile() {
+         path::append(filePath, Twine(i) + "." +
+                                    getArchitectureName(config->arch()) +
+                                    ".lto.o");
++      else if (config->ltoObjPathIsFile && i != 0)
++        filePath += Twine(i).str();
+     }
+     return filePath;
+   };
+diff --git a/lld/MachO/Options.td b/lld/MachO/Options.td
+index 5bd220b3c196..7c694d17c928 100644
+--- a/lld/MachO/Options.td
++++ b/lld/MachO/Options.td
+@@ -41,6 +41,9 @@ def thinlto_index_only: Flag<["--"], "thinlto-index-only">,
+     Group<grp_lld>;
+ def thinlto_index_only_eq: Joined<["--"], "thinlto-index-only=">,
+     Group<grp_lld>;
++def lto_obj_path_eq: Joined<["--"], "lto-obj-path=">,
++    HelpText<"Write the regular LTO object to <path>">,
++    Group<grp_lld>;
+ def thinlto_jobs_eq : Joined<["--"], "thinlto-jobs=">,
+     HelpText<"Number of ThinLTO jobs. Default to --threads=">,
+     Group<grp_lld>;

--- a/3rd_party/rules_cc/BUILD.bazel
+++ b/3rd_party/rules_cc/BUILD.bazel
@@ -1,1 +1,4 @@
-exports_files(["windows-thin-lto.patch"])
+exports_files([
+    "macos-thin-lto.patch",
+    "windows-thin-lto.patch",
+])

--- a/3rd_party/rules_cc/macos-thin-lto.patch
+++ b/3rd_party/rules_cc/macos-thin-lto.patch
@@ -1,0 +1,44 @@
+diff --git a/cc/toolchains/args/thin_lto/BUILD b/cc/toolchains/args/thin_lto/BUILD
+index 40bbc9f..774be37 100644
+--- a/cc/toolchains/args/thin_lto/BUILD
++++ b/cc/toolchains/args/thin_lto/BUILD
+@@ -45,6 +45,7 @@ cc_args(
+         ":lto_index_actions",
+     ],
+     args = select({
++        "@platforms//os:macos": ["-Wl,--thinlto-index-only={thinlto_indexing_param_file}"],
+         "@platforms//os:windows": ["-Wl,--thinlto-index-only={thinlto_indexing_param_file}"],
+         "//conditions:default": ["-Wl,-plugin-opt,thinlto-index-only={thinlto_indexing_param_file}"],
+     }),
+@@ -60,6 +61,7 @@ cc_args(
+         ":lto_index_actions",
+     ],
+     args = select({
++        "@platforms//os:macos": ["-Wl,--thinlto-emit-imports-files"],
+         "@platforms//os:windows": ["-Wl,--thinlto-emit-imports-files"],
+         "//conditions:default": ["-Wl,-plugin-opt,thinlto-emit-imports-files"],
+     }),
+@@ -71,6 +73,7 @@ cc_args(
+         ":lto_index_actions",
+     ],
+     args = select({
++        "@platforms//os:macos": ["-Wl,--thinlto-prefix-replace={thinlto_prefix_replace}"],
+         "@platforms//os:windows": ["-Wl,--thinlto-prefix-replace={thinlto_prefix_replace}"],
+         "//conditions:default": ["-Wl,-plugin-opt,thinlto-prefix-replace={thinlto_prefix_replace}"],
+     }),
+@@ -86,6 +89,7 @@ cc_args(
+         ":lto_index_actions",
+     ],
+     args = select({
++        "@platforms//os:macos": ["-Wl,--thinlto-object-suffix-replace={thinlto_object_suffix_replace}"],
+         "@platforms//os:windows": ["-Wl,--thinlto-object-suffix-replace={thinlto_object_suffix_replace}"],
+         "//conditions:default": ["-Wl,-plugin-opt,thinlto-object-suffix-replace={thinlto_object_suffix_replace}"],
+     }),
+@@ -101,6 +105,7 @@ cc_args(
+         ":lto_index_actions",
+     ],
+     args = select({
++        "@platforms//os:macos": ["-Wl,--lto-obj-path={thinlto_merged_object_file}"],
+         "@platforms//os:windows": ["-Wl,/lto-obj-path:{thinlto_merged_object_file}"],
+         "//conditions:default": ["-Wl,-plugin-opt,obj-path={thinlto_merged_object_file}"],
+     }),

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,10 @@ bazel_dep(name = "tar.bzl", version = "0.10.4")
 single_version_override(
     module_name = "rules_cc",
     patch_strip = 1,
-    patches = ["//3rd_party/rules_cc:windows-thin-lto.patch"],
+    patches = [
+        "//3rd_party/rules_cc:windows-thin-lto.patch",
+        "//3rd_party/rules_cc:macos-thin-lto.patch",
+    ],
     version = "0.2.19",
 )
 

--- a/extensions/llvm_source.bzl
+++ b/extensions/llvm_source.bzl
@@ -23,6 +23,7 @@ _DEFAULT_SOURCE_PATCHES = [
     "//3rd_party/llvm-project/x.x/patches:clang-hardlink-filenames.patch",
     "//3rd_party/llvm-project/x.x/patches:llvm-configure-reproducible.patch",
     "//3rd_party/llvm-project/x.x/patches:lld-coff-thinlto-lazy-index.patch",
+    "//3rd_party/llvm-project/x.x/patches:lld-macho-thinlto-obj-path.patch",
 ]
 
 _LLVM_21_SOURCE_PATCHES = _DEFAULT_SOURCE_PATCHES + [

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -57,18 +57,35 @@ string_flag(
 )
 
 bool_flag(
-    name = "enable_windows_thin_lto",
+    name = "is_windows_capable_of_thinlto_feature",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "is_macos_capable_of_thinlto_feature",
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "windows_thin_lto_enabled",
+    name = "macos_capable_of_thinlto_feature",
+    constraint_values = [
+        "@platforms//os:macos",
+    ],
+    flag_values = {
+        ":is_macos_capable_of_thinlto_feature": "true",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows_capable_of_thinlto_feature",
     constraint_values = [
         "@platforms//os:windows",
     ],
     flag_values = {
-        ":enable_windows_thin_lto": "true",
+        ":is_windows_capable_of_thinlto_feature": "true",
     },
     visibility = ["//visibility:public"],
 )
@@ -79,7 +96,7 @@ config_setting(
         "@platforms//os:windows",
     ],
     flag_values = {
-        ":enable_windows_thin_lto": "false",
+        ":is_windows_capable_of_thinlto_feature": "false",
     },
     visibility = ["//visibility:public"],
 )

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -17,11 +17,16 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             "@platforms//os:linux": [
                 "@rules_cc//cc/toolchains/args/thin_lto:feature",
             ],
+            # TODO: Enable macOS ThinLTO unconditionally after rules_cc and
+            # LLVM releases include macOS distributed ThinLTO support.
+            "@llvm//toolchain:macos_capable_of_thinlto_feature": [
+                "@rules_cc//cc/toolchains/args/thin_lto:feature",
+            ],
             # TODO: Enable Windows ThinLTO unconditionally after a rules_cc
             # release includes Windows ThinLTO support. The root module's
             # rules_cc patch does not propagate to dependents, so dependents
             # may use a rules_cc release without Windows ThinLTO support.
-            "@llvm//toolchain:windows_thin_lto_enabled": [
+            "@llvm//toolchain:windows_capable_of_thinlto_feature": [
                 "@rules_cc//cc/toolchains/args/thin_lto:feature",
             ],
             "//conditions:default": [],


### PR DESCRIPTION
This adds distributed ThinLTO for macOS targets after #615. The existing `windows-thin-lto.patch` remains unchanged, and the macOS rules_cc changes are isolated in `macos-thin-lto.patch`, which is applied after `windows-thin-lto.patch`. The macOS patch corresponds to bazelbuild/rules_cc#748 and only adds Mach-O LLD's direct distributed ThinLTO arguments.

The LLVM source patch adds the exact-file `--lto-obj-path` contract proposed upstream in llvm/llvm-project#203365. The exact-file contract lets the indexing action produce rules_cc's declared `thinlto_merged_object_file` without reproducing Mach-O LLD's `0.<arch>.lto.o` directory naming.

`is_windows_capable_of_thinlto_feature` and `is_macos_capable_of_thinlto_feature` default to false and independently control whether the toolchain exposes the rules_cc `thin_lto` feature on Windows and macOS. `windows_capable_of_thinlto_feature` and `macos_capable_of_thinlto_feature` combine the corresponding build setting with the target OS constraint. `--config=prebuilt` enables both build settings. `is_windows_capable_of_thinlto_feature` can be removed after a rules_cc release contains Windows distributed ThinLTO support. `is_macos_capable_of_thinlto_feature` can be removed after rules_cc and LLVM releases contain macOS distributed ThinLTO support. The previous macOS `-flto=thin` fallback is removed because rules_cc now creates separate indexing and backend actions.

Validation:

- Applied `windows-thin-lto.patch` followed by `macos-thin-lto.patch` to a clean rules_cc checkout and compared the resulting ThinLTO feature with the rules_cc source.
- `bazel test //tests/rule_based_toolchain/legacy_features_as_args:thin_lto_macos_test --test_output=errors` in rules_cc.
- `bazel build --config=prebuilt --config=remote --config=bootstrap //prebuilt/llvm:for_windows_amd64 //prebuilt/llvm:for_windows_arm64 //prebuilt/llvm:for_macos_amd64 //prebuilt/llvm:for_macos_arm64`.
- BuildBuddy invocation: https://app.buildbuddy.io/invocation/ff484673-abb8-41c9-ba4c-a19410241625
