### PR TITLE
Use llvm-22.1.7-2 prebuilts

### DIFF
--- a/3rd_party/llvm-project/x.x/patches/llvm-configure-non-reproducible.patch
+++ b/3rd_party/llvm-project/x.x/patches/llvm-configure-non-reproducible.patch
@@ -5,7 +5,7 @@ diff --git a/utils/bazel/configure.bzl b/utils/bazel/configure.bzl
          executable = False,
      )
  
-+    return repository_ctx.repo_metadata(reproducible = True)
++    return repository_ctx.repo_metadata(reproducible = False)
 +
  llvm_configure = repository_rule(
      implementation = _llvm_configure_impl,

--- a/extensions/llvm_source.bzl
+++ b/extensions/llvm_source.bzl
@@ -21,7 +21,7 @@ _DEFAULT_SOURCE_PATCHES = [
     "//3rd_party/llvm-project/x.x/patches:lit_test_stub.patch",
     "//3rd_party/llvm-project/x.x/patches:pfm-rules-cc-load.patch",
     "//3rd_party/llvm-project/x.x/patches:clang-hardlink-filenames.patch",
-    "//3rd_party/llvm-project/x.x/patches:llvm-configure-reproducible.patch",
+    "//3rd_party/llvm-project/x.x/patches:llvm-configure-non-reproducible.patch",
     "//3rd_party/llvm-project/x.x/patches:lld-coff-thinlto-lazy-index.patch",
     "//3rd_party/llvm-project/x.x/patches:lld-macho-thinlto-obj-path.patch",
 ]

--- a/extensions/llvm_toolchain_minimal_index.json
+++ b/extensions/llvm_toolchain_minimal_index.json
@@ -1,7 +1,7 @@
 {
   "latest_by_llvm_version": {
     "22.1.6": "llvm-22.1.6-1",
-    "22.1.7": "llvm-22.1.7-1"
+    "22.1.7": "llvm-22.1.7-2"
   },
   "releases": {
     "llvm-22.1.6-1": {
@@ -54,6 +54,32 @@
       "windows-arm64": {
         "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.7-1/llvm-toolchain-minimal-22.1.7-windows-arm64.tar.zst",
         "sha256": "6adee51f1cdf8bce4141b031e865ff012f359b36d527cbfb74064441328785be"
+      }
+    },
+    "llvm-22.1.7-2": {
+      "darwin-amd64": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.7-2/llvm-toolchain-minimal-22.1.7-darwin-amd64.tar.zst",
+        "sha256": "96000cc6401535c91e56418e50b974ccc7b07233e5d74c93bdf62214556be4d9"
+      },
+      "darwin-arm64": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.7-2/llvm-toolchain-minimal-22.1.7-darwin-arm64.tar.zst",
+        "sha256": "95f733b26de365e3ba2a5201e9cbfc6b168718edc15130bea1759369e7d3ecf3"
+      },
+      "linux-amd64-musl": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.7-2/llvm-toolchain-minimal-22.1.7-linux-amd64-musl.tar.zst",
+        "sha256": "d739a0f8a0f28687e64ea9edf9d98b4cd5f2f1fe72d70eb35834864a0da73bc2"
+      },
+      "linux-arm64-musl": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.7-2/llvm-toolchain-minimal-22.1.7-linux-arm64-musl.tar.zst",
+        "sha256": "194060c8282b2fb9ea89ae860be94dd8edba849c171f8932b4e47e8a1b73cf46"
+      },
+      "windows-amd64": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.7-2/llvm-toolchain-minimal-22.1.7-windows-amd64.tar.zst",
+        "sha256": "2bd103959ed7234f90f37606a5a2fd1ea578fee1bb39bb046f8e61dec7a73a8b"
+      },
+      "windows-arm64": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.7-2/llvm-toolchain-minimal-22.1.7-windows-arm64.tar.zst",
+        "sha256": "e35dc28b1f5aecc6ba3f78f6f5ef2d8cbd5fb682d36e4198b5a451acda471c47"
       }
     }
   }


### PR DESCRIPTION
This adds `llvm-22.1.7-2` to `extensions/llvm_toolchain_minimal_index.json` and sets `latest_by_llvm_version["22.1.7"]` to `llvm-22.1.7-2`. The existing `llvm-22.1.7-1` entry remains available.

`llvm-22.1.7-2` contains the Linux, macOS, and Windows distributed ThinLTO prebuilts produced from `main` commit `6d23a767189d8ab06913b5426b05ed280c97889d`. This change makes LLVM 22.1.7 prebuilt resolution select those six new archives.

The new compiler digest invalidated cached Windows compiler-rt actions and exposed `llvm_configure` declaring `llvm-project` reproducible even though `llvm-project` contains output-base-specific symlinks into `llvm-raw`. Reusing `llvm-project` across output roots leaves stale `llvm-raw` paths. Mark `llvm-project` non-reproducible while keeping `local` and `configure` unset because `llvm_configure` does not inspect the host or run host tools.

Validation:

- [LLVM Prebuilt Release run 27375078006](https://github.com/hermeticbuild/hermetic-llvm/actions/runs/27375078006) completed successfully.
- Compared all six URLs and SHA256 values with the assets in [release `llvm-22.1.7-2`](https://github.com/hermeticbuild/hermetic-llvm/releases/tag/llvm-22.1.7-2).
- Parsed `extensions/llvm_toolchain_minimal_index.json` with `python3 -m json.tool`.
- `bazel mod deps` applied `llvm-configure-non-reproducible.patch` successfully.
- `bazel --bazelrc=.bazelrc --noexperimental_remote_repo_contents_cache test //:duplicate_static_library_validator_test --test_output=errors` in `e2e/rules_cc`: [BuildBuddy invocation](https://app.buildbuddy.io/invocation/55ec3eaf-c5ff-44a2-ac93-8b378046021e).
