### PR TITLE
[codex] Preserve runtime stage in exec configurations

### DIFF
--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -14,6 +14,8 @@ package(default_visibility = ["//toolchain:__subpackages__"])
 string_setting(
     name = "runtime_stage",
     build_setting_default = "complete",
+    # Runtime transitions must survive the cc_toolchain tool_map exec transition.
+    scope = "universal",
     values = [
         "stage0",  # depend on compiler-only: CRTs, builtins, libc, static libraries.
         "stage1",  # depends on above: libunwind


### PR DESCRIPTION
## Summary

Declare `//toolchain:runtime_stage` with `scope = "universal"` so its selected value survives the `cc_toolchain.tool_map` exec transition.

Current Bazel `main` enables `--incompatible_exclude_starlark_flags_from_exec_config` by default. Without explicit universal scope, the exec transition resets `runtime_stage` to `complete`, which can select the complete tool map while one of those tools is being configured and produce a dependency cycle. The explicit scope preserves the intended runtime stage on Bazel 9.1.0 and current Bazel `main`.

## Validation

- `buildifier -mode=check toolchain/BUILD.bazel`
- `git diff --check`
