### PR TITLE
Add `module_map_home_cwd` feature

### DIFF
--- a/e2e/rules_cc/.bazelrc
+++ b/e2e/rules_cc/.bazelrc
@@ -2,4 +2,5 @@ import %workspace%/../../.bazelrc
 
 common --config=cc
 common --process_headers_in_dependencies
+common --features=layering_check
 common --modify_execution_info=CppModuleMap=+supports-path-mapping,CppArchive=+supports-path-mapping,CppCompile=+supports-path-mapping

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -365,8 +365,6 @@ cc_binary(
 cc_test(
     name = "windows_explicit_def_test",
     srcs = ["windows_explicit_def_test.cc"],
-    # Force only the test execution onto the (windows) host; the build actions
-    # cross-compile on the remote exec platform so they share one toolchain.
     exec_properties = {"test.no-remote": "1"},
     target_compatible_with = ["@platforms//os:windows"],
     deps = [":windows_explicit_def_import"],
@@ -386,8 +384,6 @@ cc_binary(
     features = ["windows_export_all_symbols"],
     linkopts = ["-Wl,--exclude-all-symbols"],
     linkshared = True,
-    # The DefParser and link actions use Windows-only tools (def_parser.exe),
-    # which can't run on the Linux remote executor.
     tags = ["no-remote"],
     target_compatible_with = ["@platforms//os:windows"],
     deps = [":windows_generated_def_library"],
@@ -890,8 +886,6 @@ cc_test(
         "duplicate_symbol_b.cc",
     ],
     env_inherit = ["PATH"],
-    # This test runs bazel-in-bazel, so its execution must stay local; the
-    # build actions still run on the (remote) default exec platform.
     exec_properties = {"test.local": "1"},
     target_compatible_with = _VALIDATE_STATIC_LIBRARY_COMPATIBLE,
     deps = ["@bazel_tools//tools/cpp/runfiles"],

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -365,10 +365,9 @@ cc_binary(
 cc_test(
     name = "windows_explicit_def_test",
     srcs = ["windows_explicit_def_test.cc"],
-    exec_compatible_with = [
-        "@platforms//os:windows",
-    ],
-    tags = ["no-remote"],
+    # Force only the test execution onto the (windows) host; the build actions
+    # cross-compile on the remote exec platform so they share one toolchain.
+    exec_properties = {"test.no-remote": "1"},
     target_compatible_with = ["@platforms//os:windows"],
     deps = [":windows_explicit_def_import"],
 )
@@ -387,6 +386,8 @@ cc_binary(
     features = ["windows_export_all_symbols"],
     linkopts = ["-Wl,--exclude-all-symbols"],
     linkshared = True,
+    # The DefParser and link actions use Windows-only tools (def_parser.exe),
+    # which can't run on the Linux remote executor.
     tags = ["no-remote"],
     target_compatible_with = ["@platforms//os:windows"],
     deps = [":windows_generated_def_library"],
@@ -401,10 +402,7 @@ cc_import(
 cc_test(
     name = "windows_generated_def_test",
     srcs = ["windows_generated_def_test.cc"],
-    exec_compatible_with = [
-        "@platforms//os:windows",
-    ],
-    tags = ["no-remote"],
+    exec_properties = {"test.no-remote": "1"},
     target_compatible_with = ["@platforms//os:windows"],
     deps = [":windows_generated_def_import"],
 )
@@ -757,14 +755,10 @@ platform_transition_binary(
 cc_test(
     name = "windows_test",
     srcs = ["windows_test.cc"],
-    exec_compatible_with = [
-        "@platforms//os:windows",
-    ],
+    exec_properties = {"test.no-remote": "1"},
     linkopts = [
         "-luuid",
     ],
-    # TODO(zbarsky): Tests can't execute remotely from Windows hosts
-    tags = ["no-remote"],
     target_compatible_with = [
         "@platforms//os:windows",
     ],
@@ -773,12 +767,8 @@ cc_test(
 cc_test(
     name = "windows_unicode_test",
     srcs = ["windows_unicode_test.cc"],
-    exec_compatible_with = [
-        "@platforms//os:windows",
-    ],
+    exec_properties = {"test.no-remote": "1"},
     linkopts = ["-municode"],
-    # TODO(zbarsky): Tests can't execute remotely from Windows hosts
-    tags = ["no-remote"],
     target_compatible_with = [
         "@platforms//os:windows",
     ],
@@ -788,11 +778,8 @@ cc_test(
     name = "pthread_test",
     srcs = ["pthread.cc"],
     copts = ["-pthread"],
-    exec_compatible_with = HOST_CONSTRAINTS,
+    exec_properties = {"test.no-remote": "1"},
     linkopts = ["-pthread"],
-    # remote-exec tests can't run without forcing the target platform to match
-    # the remote exec platform.
-    tags = ["no-remote"],
 )
 
 cc_test(
@@ -903,8 +890,9 @@ cc_test(
         "duplicate_symbol_b.cc",
     ],
     env_inherit = ["PATH"],
-    exec_compatible_with = HOST_CONSTRAINTS,
-    tags = ["local"],
+    # This test runs bazel-in-bazel, so its execution must stay local; the
+    # build actions still run on the (remote) default exec platform.
+    exec_properties = {"test.local": "1"},
     target_compatible_with = _VALIDATE_STATIC_LIBRARY_COMPATIBLE,
     deps = ["@bazel_tools//tools/cpp/runfiles"],
 )

--- a/runtimes/module_map.bzl
+++ b/runtimes/module_map.bzl
@@ -11,11 +11,8 @@ IncludePathInfo = provider(
     },
 )
 
-def _textual_header(file, *, execroot_prefix):
-    return "  textual header \"{}{}\"".format(execroot_prefix, file.path)
-
-def _umbrella_submodule(directory, *, execroot_prefix):
-    path = execroot_prefix + paths.normalize(directory.path).replace("//", "/")
+def _umbrella_submodule(directory):
+    path = paths.normalize(directory.path).replace("//", "/")
 
     return """
   module "{path}" {{
@@ -25,10 +22,6 @@ def _umbrella_submodule(directory, *, execroot_prefix):
 def _module_map_impl(ctx):
     module_map = ctx.actions.declare_file(ctx.attr.name + ".modulemap")
 
-    # The builtin include directories are relative to the execroot, but the
-    # paths in the module map must be relative to the directory that contains
-    # the module map.
-    execroot_prefix = (module_map.dirname.count("/") + 1) * "../"
     include_path_info = ctx.attr.include_path[IncludePathInfo]
 
     module_map_args = ctx.actions.args()
@@ -38,16 +31,14 @@ def _module_map_impl(ctx):
     module_map_args.add_joined(
         include_path_info.submodule_directories,
         join_with = "\n",
-        map_each = lambda directory: _umbrella_submodule(directory, execroot_prefix = execroot_prefix),
-        allow_closure = True,
+        map_each = _umbrella_submodule,
         expand_directories = False,
     )
 
     module_map_args.add_joined(
         include_path_info.textual_headers,
         join_with = "\n",
-        map_each = lambda file: _textual_header(file, execroot_prefix = execroot_prefix),
-        allow_closure = True,
+        format_each = "  textual header \"%s\"",
         expand_directories = False,
     )
 

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -9,8 +9,6 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             "@rules_cc//cc/toolchains/args/layering_check:use_module_maps",
             "@llvm//toolchain/features:static_link_cpp_runtimes",
             "@llvm//toolchain/features/runtime_library_search_directories:feature",
-            "@llvm//toolchain/features:archive_param_file",
-            "@llvm//toolchain/features:prefer_pic_for_opt_binaries",
             "@llvm//toolchain/features:parse_headers",
             "@llvm//toolchain/features:external_include_paths",
             # TODO: Restore this after a rules_cc release includes the macOS
@@ -33,17 +31,11 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
         ],
     )
 
+    # Runtime configurations have no opt-in features beyond what is already
+    # enabled, so this set is intentionally empty.
     cc_feature_set(
         name = name + "_runtimes_only_known_features",
-        all_of = [
-            # TODO(zbarsky): Do we want layering check for runtime libs?
-            #"@rules_cc//cc/toolchains/args/layering_check:layering_check",
-            #"@rules_cc//cc/toolchains/args/layering_check:use_module_maps",
-            "@llvm//toolchain/features:archive_param_file",
-            "@llvm//toolchain/features:prefer_pic_for_opt_binaries",
-            # Always last (contains user_compile_flags and user_link_flags who should apply last).
-            "@llvm//toolchain/features/legacy:experimental_replace_legacy_action_config_features",
-        ],
+        all_of = [],
     )
 
     cc_feature_set(
@@ -64,6 +56,7 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
         }) + [
             "@llvm//toolchain/features:prefer_pic_for_opt_binaries",
             "@rules_cc//cc/toolchains/args/layering_check:module_maps",
+            "@llvm//toolchain/features:module_map_home_cwd",
             # These are "enabled" but they only _actually_ get enabled when the underlying compilation mode is set.
             # This lets us properly order them before user_compile_flags and user_link_flags below.
             "@llvm//toolchain/features:opt",
@@ -80,6 +73,8 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
         name = name + "_runtimes_only_enabled_features",
         all_of = [
             "@llvm//toolchain/features:prefer_pic_for_opt_binaries",
+            "@rules_cc//cc/toolchains/args/layering_check:module_maps",
+            "@llvm//toolchain/features:module_map_home_cwd",
             "@llvm//toolchain/features:archive_param_file",
             # Always last (contains user_compile_flags and user_link_flags who should apply last).
             "@llvm//toolchain/features/legacy:experimental_replace_legacy_action_config_features",

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -31,13 +31,6 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
         ],
     )
 
-    # Runtime configurations have no opt-in features beyond what is already
-    # enabled, so this set is intentionally empty.
-    cc_feature_set(
-        name = name + "_runtimes_only_known_features",
-        all_of = [],
-    )
-
     cc_feature_set(
         name = name + "_enabled_features",
         all_of = select({
@@ -104,9 +97,9 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             "//conditions:default": [],
         }),
         known_features = select({
-            "@llvm//toolchain:runtimes_none": [name + "_runtimes_only_known_features"],
-            "@llvm//toolchain:runtimes_stage1": [name + "_runtimes_only_known_features"],
-            "@llvm//toolchain:runtimes_stage1_hosted": [name + "_runtimes_only_known_features"],
+            "@llvm//toolchain:runtimes_none": [],
+            "@llvm//toolchain:runtimes_stage1": [],
+            "@llvm//toolchain:runtimes_stage1_hosted": [],
             "//conditions:default": [name + "_known_features"],
         }),
         enabled_features = select({

--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -316,6 +316,25 @@ cc_args(
     args = ["-static"],
 )
 
+cc_args(
+    name = "module_map_home_cwd_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-Xclang",
+        "-fmodule-map-file-home-is-cwd",
+    ],
+)
+
+cc_feature(
+    name = "module_map_home_cwd",
+    args = [":module_map_home_cwd_args"],
+    feature_name = "module_map_home_cwd",
+    requires_any_of = ["@rules_cc//cc/toolchains/args/layering_check:module_maps"],
+    visibility = ["//visibility:public"],
+)
+
 ###
 
 cc_feature_set(


### PR DESCRIPTION
Cleans up the module map generation logic and makes module maps easier to read. May fix #624.

Also remove enabled features from the list of known feature as that's redundant.