### PR TITLE
Resolve tool/module-map helpers at definition site so consumers need no use_repo()

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ See https://github.com/hermeticbuild/hermetic-llvm/milestone/1
 - [Nativelink](https://github.com/TraceMachina/nativelink)
 - [formatjs](https://github.com/formatjs/formatjs)
 - [Etsy](https://etsy.com)
+- [Patagia](https://patagia.se)
 
 ## Prior art
 

--- a/toolchain/selects.bzl
+++ b/toolchain/selects.bzl
@@ -2,24 +2,24 @@ LLVM_VERSION = "22.1.7"
 
 def platform_llvm_binary(binary):
     return select({
-        "@llvm//platforms/config:macos_x86_64_prebuilt": "@llvm-toolchain-minimal-%s-darwin-amd64//:bin/%s" % (LLVM_VERSION, binary),
-        "@llvm//platforms/config:macos_aarch64_prebuilt": "@llvm-toolchain-minimal-%s-darwin-arm64//:bin/%s" % (LLVM_VERSION, binary),
-        "@llvm//platforms/config:linux_x86_64_prebuilt": "@llvm-toolchain-minimal-%s-linux-amd64//:bin/%s" % (LLVM_VERSION, binary),
-        "@llvm//platforms/config:linux_aarch64_prebuilt": "@llvm-toolchain-minimal-%s-linux-arm64//:bin/%s" % (LLVM_VERSION, binary),
-        "@llvm//platforms/config:windows_aarch64_prebuilt": "@llvm-toolchain-minimal-%s-windows-arm64//:bin/%s.exe" % (LLVM_VERSION, binary),
-        "@llvm//platforms/config:windows_x86_64_prebuilt": "@llvm-toolchain-minimal-%s-windows-amd64//:bin/%s.exe" % (LLVM_VERSION, binary),
-        "@llvm//toolchain:bootstrapped_toolchain": "@llvm//toolchain/bootstrap:" + binary,
+        "@llvm//platforms/config:macos_x86_64_prebuilt": Label("@llvm-toolchain-minimal-%s-darwin-amd64//:bin/%s" % (LLVM_VERSION, binary)),
+        "@llvm//platforms/config:macos_aarch64_prebuilt": Label("@llvm-toolchain-minimal-%s-darwin-arm64//:bin/%s" % (LLVM_VERSION, binary)),
+        "@llvm//platforms/config:linux_x86_64_prebuilt": Label("@llvm-toolchain-minimal-%s-linux-amd64//:bin/%s" % (LLVM_VERSION, binary)),
+        "@llvm//platforms/config:linux_aarch64_prebuilt": Label("@llvm-toolchain-minimal-%s-linux-arm64//:bin/%s" % (LLVM_VERSION, binary)),
+        "@llvm//platforms/config:windows_aarch64_prebuilt": Label("@llvm-toolchain-minimal-%s-windows-arm64//:bin/%s.exe" % (LLVM_VERSION, binary)),
+        "@llvm//platforms/config:windows_x86_64_prebuilt": Label("@llvm-toolchain-minimal-%s-windows-amd64//:bin/%s.exe" % (LLVM_VERSION, binary)),
+        "@llvm//toolchain:bootstrapped_toolchain": Label("@llvm//toolchain/bootstrap:" + binary),
     })
 
 def platform_extra_binary(binary):
     return select({
-        "@llvm//platforms/config:macos_x86_64": "@toolchain-extra-prebuilts-darwin-amd64//:%s" % binary,
-        "@llvm//platforms/config:macos_aarch64": "@toolchain-extra-prebuilts-darwin-arm64//:%s" % binary,
-        "@llvm//platforms/config:linux_x86_64": "@toolchain-extra-prebuilts-linux-amd64//:%s" % binary,
-        "@llvm//platforms/config:linux_aarch64": "@toolchain-extra-prebuilts-linux-arm64//:%s" % binary,
+        "@llvm//platforms/config:macos_x86_64": Label("@toolchain-extra-prebuilts-darwin-amd64//:%s" % binary),
+        "@llvm//platforms/config:macos_aarch64": Label("@toolchain-extra-prebuilts-darwin-arm64//:%s" % binary),
+        "@llvm//platforms/config:linux_x86_64": Label("@toolchain-extra-prebuilts-linux-amd64//:%s" % binary),
+        "@llvm//platforms/config:linux_aarch64": Label("@toolchain-extra-prebuilts-linux-arm64//:%s" % binary),
         # TODO(zbarsky): should we suffix these with `.exe` in the dist?
-        "@llvm//platforms/config:windows_aarch64": "@toolchain-extra-prebuilts-windows-arm64//:%s" % binary,
-        "@llvm//platforms/config:windows_x86_64": "@toolchain-extra-prebuilts-windows-amd64//:%s" % binary,
+        "@llvm//platforms/config:windows_aarch64": Label("@toolchain-extra-prebuilts-windows-arm64//:%s" % binary),
+        "@llvm//platforms/config:windows_x86_64": Label("@toolchain-extra-prebuilts-windows-amd64//:%s" % binary),
     })
 
 def _tool_repo(exec_os, exec_cpu):
@@ -28,10 +28,10 @@ def _tool_repo(exec_os, exec_cpu):
     return "@llvm-toolchain-minimal-%s-%s-%s//" % (LLVM_VERSION, os_part, cpu_part)
 
 def platform_module_map(exec_os, exec_cpu):
-    return _tool_repo(exec_os, exec_cpu) + ":module_map"
+    return Label(_tool_repo(exec_os, exec_cpu) + ":module_map")
 
 def resource_dir_arg(exec_os, exec_cpu):
-    return _tool_repo(exec_os, exec_cpu) + ":compile_resource_dir"
+    return Label(_tool_repo(exec_os, exec_cpu) + ":compile_resource_dir")
 
 def platform_cc_tool_map(exec_os, exec_cpu):
     tool_repo = _tool_repo(exec_os, exec_cpu)
@@ -41,8 +41,8 @@ def platform_cc_tool_map(exec_os, exec_cpu):
     # point at further aliases that use `select`, those will resolve according to the exec platform.
     # See https://github.com/bazelbuild/bazel/issues/27623#issuecomment-3529439585 for more details.
     return select({
-        "@llvm//toolchain:macos_complete_with_libtool": tool_repo + ":tools_with_dsym_and_libtool",
-        "@llvm//toolchain:macos_complete": tool_repo + ":tools_with_dsym",
-        "@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_apple_setting": tool_repo + ":tools_with_libtool_for_runtime",
-        "//conditions:default": tool_repo + ":default_tools_for_runtime",
+        "@llvm//toolchain:macos_complete_with_libtool": Label(tool_repo + ":tools_with_dsym_and_libtool"),
+        "@llvm//toolchain:macos_complete": Label(tool_repo + ":tools_with_dsym"),
+        "@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_apple_setting": Label(tool_repo + ":tools_with_libtool_for_runtime"),
+        "//conditions:default": Label(tool_repo + ":default_tools_for_runtime"),
     })


### PR DESCRIPTION
platform_cc_tool_map / platform_module_map / resource_dir_arg are public: downstream modules compose their own cc_toolchain from them (e.g. with a custom sysroot). They returned bare label strings built from _tool_repo(), so the @llvm-toolchain-minimal-<version>-<platform> repo resolved in the *caller's* repo mapping. That forced every such consumer to use_repo() that repo in their MODULE.bazel — a repo the extension reports as indirect, so bzlmod prints an "incorrect imports" warning, and the version-pinned repo name has to be hand-updated on every LLVM bump.

Wrap the returned labels in Label() so they resolve against this module's own repo mapping at definition site. Consumers no longer need use_repo() and never name the versioned repo. select() keys stay as strings (they are @llvm// / @rules_cc//, already direct deps of any consumer composing a rules_cc toolchain).

Fixes #621.