### PR TITLE
Add rules_cc fission coverage

### DIFF
--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -17,6 +17,7 @@ load(
     "asan_cc_binary",
     "cfi_cc_binary",
     "dfsan_cc_binary",
+    "fission_cc_binary",
     "fuzzer_asan_cc_binary",
     "fuzzer_cc_binary",
     "lsan_cc_binary",
@@ -50,6 +51,11 @@ _DSYM_OUTPUT_TEST_ENV = {
     "DSYM_BUNDLE": "$(rootpath :main_dsym_bundle)",
     "DWARF_FILE": "main_dsym",
 } if _DSYM_OUTPUT_TEST_BAZEL9_COMPATIBLE else {}
+
+_FISSION_TEST_COMPATIBLE = select({
+    "@platforms//os:linux": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+}) if bazel_features.cc.supports_starlarkified_toolchains else ["@platforms//:incompatible"]
 
 musl_header_generation_tests(name = "musl_header_generation_tests")
 
@@ -448,6 +454,20 @@ cc_binary(
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+)
+
+fission_cc_binary(
+    name = "fission_main",
+    srcs = ["main.cc"],
+    target_compatible_with = _FISSION_TEST_COMPATIBLE,
+)
+
+sh_test(
+    name = "fission_debug_package_test",
+    srcs = ["fission_debug_package_test.sh"],
+    data = [":fission_main.dwp"],
+    env = {"DWP": "$(rootpath :fission_main.dwp)"},
+    target_compatible_with = _FISSION_TEST_COMPATIBLE,
 )
 
 cc_binary(

--- a/e2e/rules_cc/defs.bzl
+++ b/e2e/rules_cc/defs.bzl
@@ -33,6 +33,14 @@ dfsan_cc_binary, _dfsan_cc_binary_internal = with_cfg(cc_binary).set(
     True,
 ).build()
 
+fission_cc_binary, _fission_cc_binary_internal = with_cfg(cc_binary).set(
+    "compilation_mode",
+    "dbg",
+).set(
+    "fission",
+    ["dbg"],
+).build()
+
 nsan_cc_binary, _nsan_cc_binary_internal = with_cfg(cc_binary).set(
     Label("@llvm//config:nsan"),
     True,

--- a/e2e/rules_cc/fission_debug_package_test.sh
+++ b/e2e/rules_cc/fission_debug_package_test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -s "${DWP}" ]]; then
+  echo "missing or empty fission debug package: ${DWP}" >&2
+  exit 1
+fi
+
+for section in .debug_cu_index .debug_info.dwo; do
+  if ! LC_ALL=C grep -a -F -q "${section}" "${DWP}"; then
+    echo "fission debug package is missing ${section}: ${DWP}" >&2
+    exit 1
+  fi
+done

--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -17,7 +17,7 @@ _DSYM_COMPILE_ACTIONS = [
 # [] fastbuild
 # [] static_linking_mode - does this do anything? Seems obsolete
 # [] dynamic_linking_mode
-# [] per_object_debug_info
+# [x] per_object_debug_info
 # [x] static_link_cpp_runtimes
 
 cc_feature(


### PR DESCRIPTION
## Summary

Add a `fission_cc_binary` configuration that builds C++ binaries in `dbg` mode with `fission=["dbg"]`. Add a Linux Bazel 9 end-to-end test that builds `fission_main.dwp` and verifies that the package contains `.debug_cu_index` and `.debug_info.dwo`.

The LLVM toolchain already enables rules_cc's `per_object_debug_info` and `fission_support` features and maps the `dwp` action to `llvm-dwp`; this change adds direct coverage for that configuration. The test is incompatible with Bazel 8 because Bazel 8's built-in `cc_binary` requires a legacy `dwp` tool path instead of the rule-based `dwp` action.

## Validation

- `bazel test --config=remote --remote_download_outputs=all --platforms=@llvm//:rbe_platform //:fission_debug_package_test` with Bazel 9.1.1
- `buildifier -mode=check e2e/rules_cc/BUILD.bazel e2e/rules_cc/defs.bzl toolchain/features/BUILD.bazel`
- `bash -n e2e/rules_cc/fission_debug_package_test.sh`
- `git diff --check`
