### PR TITLE
[codex] Pass -lc++ for macOS target

### DIFF
--- a/toolchain/args/macos/BUILD.bazel
+++ b/toolchain/args/macos/BUILD.bazel
@@ -49,6 +49,10 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
     args = [
+        # The macOS toolchain has no resource directory, so add libc++ here.
+        # This is incorrect for C links, but rules_cc cannot distinguish C links
+        # from C++ links.
+        "-lc++",
         "-headerpad_max_install_names",
         "-Wl,-no_warn_duplicate_libraries",
         "-Wl,-oso_prefix,.",  # Strip absolute paths from debug info file references


### PR DESCRIPTION
By Codex

`toolchain/args/macos/BUILD.bazel` now adds `-lc++` to `default_link_flags`. The macOS toolchain does not configure `resource_dir`, so Clang does not add libc++ automatically. `rules_cc` cannot distinguish C link actions from C++ link actions here, so C programs also receive `-lc++`; the comment next to the flag documents that limitation.

Validation:

- `buildifier -mode=check -lint=warn toolchain/args/macos/BUILD.bazel`
- `git diff --check`
- A macOS AArch64 `bazel aquery` confirmed that the generated link command contains `-lc++`.