### PR TITLE
Use upstream rules_cc def file args

### DIFF
--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -44,7 +44,7 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             "@platforms//os:windows": [
                 "@llvm//toolchain/features:static_link_cpp_runtimes",
                 "@llvm//toolchain/features/runtime_library_search_directories:feature",
-                "@llvm//toolchain/features:def_file",
+                "@rules_cc//cc/toolchains/args/def_file:def_file",
                 "@llvm//toolchain/features:targets_windows",
             ],
             "@platforms//os:none": [],

--- a/toolchain/features/BUILD.bazel
+++ b/toolchain/features/BUILD.bazel
@@ -56,24 +56,6 @@ cc_feature(
     implies = [":copy_dynamic_libraries_to_binary"],
 )
 
-cc_args(
-    name = "def_file_link_args",
-    actions = [
-        "@rules_cc//cc/toolchains/actions:link_actions",
-    ],
-    args = ["{def_file_path}"],
-    format = {
-        "def_file_path": "@rules_cc//cc/toolchains/variables:def_file_path",
-    },
-    requires_not_none = "@rules_cc//cc/toolchains/variables:def_file_path",
-)
-
-cc_feature(
-    name = "def_file",
-    args = [":def_file_link_args"],
-    feature_name = "def_file",
-)
-
 cc_feature(
     name = "windows_export_all_symbols",
     feature_name = "windows_export_all_symbols",
@@ -402,7 +384,7 @@ cc_feature_set(
     ] + select({
         "@platforms//os:windows": [
             ":copy_dynamic_libraries_to_binary",
-            ":def_file",
+            "@rules_cc//cc/toolchains/args/def_file:def_file",
             ":no_windows_export_all_symbols",
             ":targets_windows",
             ":windows_export_all_symbols",


### PR DESCRIPTION
## Summary

- Remove the local `def_file` feature/args now that `rules_cc@0.2.20` provides it.
- Enable `@rules_cc//cc/toolchains/args/def_file:def_file` directly for Windows toolchains.

## Validation

- `bazel build //:main --config=remote` from `e2e/rules_cc`
- `bazel build //:windows_explicit_def.dll --config=remote --platforms=@llvm//platforms:windows_x86_64` from `e2e/rules_cc`