### PR TITLE
Pass -isysroot on macOS as well as --sysroot

### DIFF
--- a/toolchain/args/macos/BUILD.bazel
+++ b/toolchain/args/macos/BUILD.bazel
@@ -9,12 +9,14 @@ package(default_visibility = ["//visibility:public"])
 
 cc_sysroot(
     name = "macos_sdk_sysroot",
-    allowlist_include_directories = [
-        "@macos_sdk//sysroot",
+    allowlist_include_directories = ["@macos_sdk//sysroot"],
+    # NOTE: cc_sysroot automatically passes --sysroot=, but clang has some
+    # defaulting logic if we don't also pass -isysroot
+    args = [
+        "-isysroot",
+        "{sysroot}",
     ],
-    data = [
-        "@macos_sdk//sysroot",
-    ],
+    data = ["@macos_sdk//sysroot"],
     sysroot = "@macos_sdk//sysroot",
 )
 


### PR DESCRIPTION
For compilation clang looks at -isysroot, then the SDKROOT env var, and
then the --sysroot flag. Previously we passed --sysroot (which is done
by cc_sysroot), but we didn't pass this. This meant if the build had
SDKROOT set globally for some reason, clang would pick that over the
hermetic one. It's likely a bug if anyone ever manually sets SDKROOT but
we might as well be safe here from future defaulting logic like this.

https://github.com/llvm/llvm-project/blob/8a531c3608c722ad529be448d6ecef06ba107228/clang/lib/Driver/ToolChains/Darwin.cpp#L2581-L2599
