### PR TITLE
Fix clang-tidy multicall registration

### DIFF
--- a/3rd_party/llvm-project/x.x/patches/llvm-driver-tool-order.patch
+++ b/3rd_party/llvm-project/x.x/patches/llvm-driver-tool-order.patch
@@ -1,17 +1,101 @@
+diff --git a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
++++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+@@ -14 +14 @@
+-load(":driver.bzl", "generate_driver_selects", "generate_driver_tools_def", "llvm_driver_cc_binary", "select_driver_tools")
++load(":driver.bzl", "generate_driver_selects", "generate_driver_tools_def", "llvm_driver_cc_binary")
+@@ -771,3 +771,3 @@
+ # Command line flag to control which tools get included in the llvm driver binary.
+-# The macro also generates config_setting targets used by select_driver_tools().
+-generate_driver_selects(name = "driver-tools")
++# The macro also returns the selected tool dependencies.
++driver_tool_deps = generate_driver_selects(name = "driver-tools")
+@@ -775,5 +775,5 @@
+ generate_driver_tools_def(
+     name = "gen_llvm_driver_tools_def",
+     out = "LLVMDriverTools.def",
+-    driver_tools = select_driver_tools(":driver-tools"),
++    driver_tools = ":driver-tools",
+ )
+@@ -791,5 +791,5 @@
+     deps = [
+         ":Support",
+         ":llvm_driver_tools_def_lib",
+-    ] + select_driver_tools(":driver-tools"),
++    ] + driver_tool_deps,
+ )
+diff --git a/utils/bazel/llvm-project-overlay/llvm/driver.bzl b/utils/bazel/llvm-project-overlay/llvm/driver.bzl
 --- a/utils/bazel/llvm-project-overlay/llvm/driver.bzl
 +++ b/utils/bazel/llvm-project-overlay/llvm/driver.bzl
-@@ -128,9 +128,12 @@
+@@ -87,3 +87,5 @@
+     Args:
+       name: the name of the flag that configures which tools are included.
++    Returns:
++      Selected driver tool dependencies.
+     """
+@@ -91,26 +93,16 @@
+     _validated_string_list_flag(
+         name = name,
+         build_setting_default = _TOOLS.keys(),
+         values = _TOOLS.keys(),
+     )
+-    for tool in _TOOLS.keys():
++    driver_tool_deps = []
++    for tool, target in _TOOLS.items():
+         native.config_setting(
+             name = "{}-include-{}".format(name, tool),
+             flag_values = {name: tool},
+         )
+-
+-def select_driver_tools(flag):
+-    """Produce a list of tool deps based on generate_driver_selects().
+-
+-    Args:
+-      flag: name that was used for generate_driver_selects().
+-    Returns:
+-      List of tool deps based on generate_driver_selects().
+-    """
+-    tools = []
+-    for tool, target in _TOOLS.items():
+-        tools += select({
+-            "{}-include-{}".format(flag, tool): [target],
++        driver_tool_deps += select({
++            "{}-include-{}".format(name, tool): [target],
+             "//conditions:default": [],
+         })
+-    return tools
++    return driver_tool_deps
+@@ -118,17 +118,11 @@
+ def _generate_driver_tools_def_impl(ctx):
+-    # Depending on how the LLVM build files are included,
+-    # it may or may not have the @llvm-project repo prefix.
+-    # Compare just on the name. We could also include the package,
+-    # but the name itself is unique in practice.
+-    label_to_name = {Label(v).name: k for k, v in _TOOLS.items()}
+-
+     # Reverse sort by the *main* tool name, but keep aliases together.
      # This is consistent with how tools/llvm-driver/CMakeLists.txt does it,
      # and this makes sure that more specific tools are checked first.
      # For example, "clang-scan-deps" should not match "clang".
 -    tools = [label_to_name[tool.label.name] for tool in ctx.attr.driver_tools]
-+    tools = sorted(
-+        [label_to_name[tool.label.name] for tool in ctx.attr.driver_tools],
-+        reverse = True,
-+    )
++    tools = sorted(ctx.attr.driver_tools[BuildSettingInfo].value, reverse = True)
      tool_alias_pairs = []
 -    for tool_name in reversed(tools):
 +    for tool_name in tools:
          tool_alias_pairs.append((tool_name, tool_name))
          for extra_alias in _EXTRA_ALIASES.get(tool_name, []):
              tool_alias_pairs.append((tool_name, extra_alias))
+@@ -158,9 +152,10 @@
+     doc = """Generate a list of LLVM_DRIVER_TOOL macros.
+ See tools/llvm-driver/CMakeLists.txt for the reference implementation.""",
+     attrs = {
+-        "driver_tools": attr.label_list(
+-            doc = "List of tools to include in the generated header. Use select_driver_tools() to provide this.",
+-            providers = [CcInfo],
++        "driver_tools": attr.label(
++            doc = "Build setting created by generate_driver_selects().",
++            mandatory = True,
++            providers = [BuildSettingInfo],
+         ),
+         "out": attr.output(
+             doc = "Name of the generated .def output file.",


### PR DESCRIPTION
Read selected tool names directly from the driver-tools build setting when generating LLVMDriverTools.def. The label-name reverse map treated //clang-tools-extra/clang-tidy:tool and //clang-tools-extra/clangd:tool as the same target name. Have generate_driver_selects return driver_tool_deps and remove select_driver_tools.

Fixes https://github.com/hermeticbuild/hermetic-llvm/issues/640