### PR TITLE
Update LLVM to 22.1.8

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ http_archive(
     urls = ["https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz"],
 )
 
-LLVM_VERSION = "22.1.7"
+LLVM_VERSION = "22.1.8"
 
 PREBUILT_LLVM_VERSION = "22.1.7"
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,7 +32,7 @@ http_archive(
 
 LLVM_VERSION = "22.1.8"
 
-PREBUILT_LLVM_VERSION = "22.1.7"
+PREBUILT_LLVM_VERSION = "22.1.8"
 
 llvm_toolchain_minimal = use_extension("//extensions:llvm_toolchain_minimal.bzl", "llvm_toolchain_minimal")
 llvm_toolchain_minimal.index(file = "//extensions:llvm_toolchain_minimal_index.json")
@@ -41,12 +41,12 @@ llvm_toolchain_minimal.release(
 )
 use_repo(
     llvm_toolchain_minimal,
-    "llvm-toolchain-minimal-22.1.7-darwin-amd64",
-    "llvm-toolchain-minimal-22.1.7-darwin-arm64",
-    "llvm-toolchain-minimal-22.1.7-linux-amd64",
-    "llvm-toolchain-minimal-22.1.7-linux-arm64",
-    "llvm-toolchain-minimal-22.1.7-windows-amd64",
-    "llvm-toolchain-minimal-22.1.7-windows-arm64",
+    "llvm-toolchain-minimal-22.1.8-darwin-amd64",
+    "llvm-toolchain-minimal-22.1.8-darwin-arm64",
+    "llvm-toolchain-minimal-22.1.8-linux-amd64",
+    "llvm-toolchain-minimal-22.1.8-linux-arm64",
+    "llvm-toolchain-minimal-22.1.8-windows-amd64",
+    "llvm-toolchain-minimal-22.1.8-windows-arm64",
 )
 
 TOOLCHAIN_EXTRAS_SHA256 = {

--- a/extensions/llvm_toolchain_minimal_index.json
+++ b/extensions/llvm_toolchain_minimal_index.json
@@ -1,7 +1,8 @@
 {
   "latest_by_llvm_version": {
     "22.1.6": "llvm-22.1.6-1",
-    "22.1.7": "llvm-22.1.7-2"
+    "22.1.7": "llvm-22.1.7-2",
+    "22.1.8": "llvm-22.1.8-1"
   },
   "releases": {
     "llvm-22.1.6-1": {
@@ -80,6 +81,32 @@
       "windows-arm64": {
         "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.7-2/llvm-toolchain-minimal-22.1.7-windows-arm64.tar.zst",
         "sha256": "e35dc28b1f5aecc6ba3f78f6f5ef2d8cbd5fb682d36e4198b5a451acda471c47"
+      }
+    },
+    "llvm-22.1.8-1": {
+      "darwin-amd64": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.8-1/llvm-toolchain-minimal-22.1.8-darwin-amd64.tar.zst",
+        "sha256": "fe044d62acf0b9aeaa8f1cf2ec9fa19fa4f4b9320a5e4152d91acde903dd809c"
+      },
+      "darwin-arm64": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.8-1/llvm-toolchain-minimal-22.1.8-darwin-arm64.tar.zst",
+        "sha256": "53b7a8a8d4ff638c967e8cc4d19a796a82e1e082289afb2f1e30ca7432435b11"
+      },
+      "linux-amd64-musl": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.8-1/llvm-toolchain-minimal-22.1.8-linux-amd64-musl.tar.zst",
+        "sha256": "89f29294a584267251edac00ab723a0a74514b8e1acb7f036840d13635c66bfa"
+      },
+      "linux-arm64-musl": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.8-1/llvm-toolchain-minimal-22.1.8-linux-arm64-musl.tar.zst",
+        "sha256": "2914968f1fff964c654627599d15ade423e17ed310b09e2d6b61e82c16a1993d"
+      },
+      "windows-amd64": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.8-1/llvm-toolchain-minimal-22.1.8-windows-amd64.tar.zst",
+        "sha256": "7109946742971dee78a325904bcfa414030317c26a84842b5998b15b5e2f7164"
+      },
+      "windows-arm64": {
+        "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.8-1/llvm-toolchain-minimal-22.1.8-windows-arm64.tar.zst",
+        "sha256": "b65f380f32cec910a761b5107a2fe25f8322c7e8a6561bfe40077e8360a2a647"
       }
     }
   }

--- a/llvm_versions.json
+++ b/llvm_versions.json
@@ -34,5 +34,9 @@
   "22.1.7": {
     "url": "https://github.com/hermeticbuild/llvm-redist/releases/download/llvmorg-22.1.7-r1/llvm-project-22.1.7.src.tar.zst",
     "sha256": "6ef7e6986ef1fd5a0074f249e161977c7c0e47d2a9eebcdb9fc1ddf483223aad"
+  },
+  "22.1.8": {
+    "url": "https://github.com/hermeticbuild/llvm-redist/releases/download/llvmorg-22.1.8-r1/llvm-project-22.1.8.src.tar.zst",
+    "sha256": "0a120cd02aa4319887b938ed98f34907563e9b4bcdd4a2aed23a1a05dd5a8157"
   }
 }

--- a/toolchain/bootstrap/bootstrap_binary.bzl
+++ b/toolchain/bootstrap/bootstrap_binary.bzl
@@ -91,7 +91,7 @@ def _bootstrap_binary_impl(ctx):
         DefaultInfo(
             files = depset([out]),
             executable = out,
-            runfiles = actual.default_runfiles,
+            runfiles = ctx.runfiles(files = [exe]).merge(actual.default_runfiles),
         ),
     ]
 

--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -321,6 +321,10 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
         }) + [
             prefix + "/bin/c++filt",
             prefix + "/bin/llvm-nm",
+            # CcToolchainInfo.all_files only includes rules_cc's
+            # LEGACY_FILE_GROUPS. Include llvm-profdata for
+            # LLVMFDOProfileMerge.
+            prefix + "/bin/llvm-profdata",
         ],
     )
 

--- a/toolchain/selects.bzl
+++ b/toolchain/selects.bzl
@@ -1,6 +1,6 @@
 load("//platforms:common.bzl", "SUPPORTED_EXECS")
 
-LLVM_VERSION = "22.1.7"
+LLVM_VERSION = "22.1.8"
 
 def _tool_repo(exec_os, exec_cpu):
     os_part = "darwin" if exec_os == "macos" else exec_os


### PR DESCRIPTION
Updates `LLVM_VERSION` and `PREBUILT_LLVM_VERSION` to `22.1.8`, adds the `llvmorg-22.1.8-r1` source metadata, and selects release `llvm-22.1.8-1` for all six minimal toolchain repositories. This stacked branch intentionally includes the two commits from `llvm-22.1.8-1`: `build: prepare LLVM 22.1.8 prebuilts` and `Include llvm-profdata in bootstrap toolchain inputs`; the latter declares `llvm-profdata` in bootstrap toolchain inputs and runfiles so `LLVMFDOProfileMerge` can execute remotely.

Validation: [LLVM Prebuilt Release run 28239969797](https://github.com/hermeticbuild/hermetic-llvm/actions/runs/28239969797) completed successfully; [release `llvm-22.1.8-1`](https://github.com/hermeticbuild/hermetic-llvm/releases/tag/llvm-22.1.8-1) contains all six archives, `SHA256.txt`, and the attestation bundle; and every URL and SHA256 in `extensions/llvm_toolchain_minimal_index.json` was compared with the published release.