### PR TITLE
Select minimal prebuilts from llvm.version

### DIFF
--- a/.agents/skills/update-llvm-version/SKILL.md
+++ b/.agents/skills/update-llvm-version/SKILL.md
@@ -24,9 +24,9 @@ argument-hint: 'Target LLVM version, optionally with prebuilt suffix number'
 This workflow has two phases:
 
 1. Build and publish prebuilts from a branch named llvm-<version>-<suffix>.
-2. Consume those prebuilts from a branch named update-llvm-<version> by updating MODULE.bazel, the prebuilt index, and opening a PR.
+2. Consume those prebuilts from a branch named update-llvm-<version> by updating the prebuilt index and opening a PR.
 
-The first branch must keep PREBUILT_LLVM_VERSION unchanged. The second branch switches PREBUILT_LLVM_VERSION and the checked-in llvm-toolchain-minimal index to the newly published release.
+The first branch changes LLVM_VERSION before the new prebuilt release exists, so the llvm_toolchain_minimal extension uses default_prebuilt_llvm_version from the checked-in index as the bootstrap seed. The second branch maps the new LLVM_VERSION to the newly published release in the checked-in llvm-toolchain-minimal index.
 Pushes, release inspection, and PR creation should be performed automatically unless the user overrides that behavior.
 Do not run local builds unless the user explicitly asks. Default verification is the LLVM Prebuilt Release workflow plus the final PR CI.
 
@@ -45,7 +45,7 @@ Do not run local builds unless the user explicitly asks. Default verification is
 
 3. Edit MODULE.bazel:
    - Set LLVM_VERSION to the new version.
-   - Leave PREBUILT_LLVM_VERSION unchanged.
+   - Do not change default_prebuilt_llvm_version in extensions/llvm_toolchain_minimal_index.json; it remains the bootstrap seed until the new release is published.
 4. Commit the change and push the branch.
 5. Monitor the LLVM Prebuilt Release workflow for that branch push.
    - Expect the successful run to often take roughly 20 to 30 minutes.
@@ -72,11 +72,8 @@ Do not run local builds unless the user explicitly asks. Default verification is
 5. Edit extensions/llvm_toolchain_minimal_index.json:
    - Add or replace the new `llvm-<version>-<suffix>` entry under `releases` with the published URLs and sha256 values.
    - Set `latest_by_llvm_version["<version>"]` to `llvm-<version>-<suffix>`.
-6. Edit MODULE.bazel:
-   - Set PREBUILT_LLVM_VERSION to the new version.
-   - Keep LLVM_VERSION at the new version.
-7. Edit toolchain/selects.bzl:
-   - Set LLVM_VERSION to the new version.
+6. Set `default_prebuilt_llvm_version` to the new version when the repository default should advance to the new release.
+7. Keep LLVM_VERSION in MODULE.bazel at the new version. The llvm_toolchain_minimal extension automatically materializes the release selected by latest_by_llvm_version.
 8. Commit and push update-llvm-<version>.
 9. Open a PR from update-llvm-<version> to main.
 10. Make it explicit in the PR body or branch strategy that the PR intentionally includes the commits from the prior llvm-* branch when the branch is stacked that way.
@@ -123,8 +120,8 @@ gh pr create --base main --head update-llvm-<version> --fill
 - LLVM_VERSION is updated to the target version.
 - The llvm-<version>-<suffix> branch successfully published its GitHub release.
 - The release contains SHA256.txt and all six minimal toolchain archives.
-- PREBUILT_LLVM_VERSION matches the published prebuilt version.
 - extensions/llvm_toolchain_minimal_index.json maps the LLVM version to the chosen release suffix.
+- default_prebuilt_llvm_version identifies the intended fallback bootstrap seed.
 - extensions/llvm_toolchain_minimal_index.json matches the published release URLs and checksums exactly.
 - The update-llvm-<version> branch is pushed.
 - A PR targeting main exists for the final branch.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -233,6 +233,20 @@ jobs:
         run: |
           bazel build --nobuild //toolchain/bootstrap/stage1:llvm
 
+      - name: Verify consumer prebuilt LLVM ${{ matrix.llvm_version }} selection
+        env:
+          LLVM_VERSION: ${{ matrix.llvm_version }}
+        working-directory: e2e/llvm_version_selection
+        shell: bash
+        run: |
+          bazel --bazelrc=/dev/null build --nobuild //:hello --lockfile_mode=off
+          resource_dir="$(bazel --bazelrc=/dev/null cquery @llvm//:builtin_resource_dir --output=files --lockfile_mode=off)"
+          expected_suffix="/lib/clang/${LLVM_VERSION%%.*}"
+          if [[ "${resource_dir}" != *"${expected_suffix}" ]]; then
+            echo "Expected LLVM ${LLVM_VERSION} resource directory ending in ${expected_suffix}, got ${resource_dir}" >&2
+            exit 1
+          fi
+
   tests:
     strategy:
       fail-fast: false

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
-load("//toolchain:selects.bzl", "LLVM_VERSION")
 
 # gazelle:map_kind bzl_library bzl_library @bazel_lib//:bzl_library.bzl
 # gazelle:exclude tests
@@ -30,12 +29,12 @@ alias(
 alias(
     name = "builtin_resource_dir",
     actual = select({
-        "//platforms/config:macos_x86_64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-%s-darwin-amd64//:builtin_resource_dir" % LLVM_VERSION,
-        "//platforms/config:macos_aarch64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-%s-darwin-arm64//:builtin_resource_dir" % LLVM_VERSION,
-        "//platforms/config:linux_x86_64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-%s-linux-amd64//:builtin_resource_dir" % LLVM_VERSION,
-        "//platforms/config:linux_aarch64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-%s-linux-arm64//:builtin_resource_dir" % LLVM_VERSION,
-        "//platforms/config:windows_aarch64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-%s-windows-arm64//:builtin_resource_dir" % LLVM_VERSION,
-        "//platforms/config:windows_x86_64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-%s-windows-amd64//:builtin_resource_dir" % LLVM_VERSION,
+        "//platforms/config:macos_x86_64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-darwin-amd64//:builtin_resource_dir",
+        "//platforms/config:macos_aarch64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-darwin-arm64//:builtin_resource_dir",
+        "//platforms/config:linux_x86_64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-linux-amd64//:builtin_resource_dir",
+        "//platforms/config:linux_aarch64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-linux-arm64//:builtin_resource_dir",
+        "//platforms/config:windows_aarch64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-windows-arm64//:builtin_resource_dir",
+        "//platforms/config:windows_x86_64_stage0_prebuilt_seed": "@llvm-toolchain-minimal-windows-amd64//:builtin_resource_dir",
     }),
     visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,21 +33,33 @@ http_archive(
 
 LLVM_VERSION = "22.1.8"
 
-PREBUILT_LLVM_VERSION = "22.1.8"
+llvm = use_extension("//extensions:llvm.bzl", "llvm")
+llvm.version(llvm_version = LLVM_VERSION)
+llvm.configure(
+    targets = [
+        "AArch64",
+        "AMDGPU",
+        "ARM",
+        "BPF",
+        "NVPTX",
+        "RISCV",
+        "SystemZ",
+        "WebAssembly",
+        "X86",
+    ],
+)
+use_repo(llvm, "llvm-project", "llvm_version")
 
 llvm_toolchain_minimal = use_extension("//extensions:llvm_toolchain_minimal.bzl", "llvm_toolchain_minimal")
 llvm_toolchain_minimal.index(file = "//extensions:llvm_toolchain_minimal_index.json")
-llvm_toolchain_minimal.release(
-    llvm_version = PREBUILT_LLVM_VERSION,
-)
 use_repo(
     llvm_toolchain_minimal,
-    "llvm-toolchain-minimal-22.1.8-darwin-amd64",
-    "llvm-toolchain-minimal-22.1.8-darwin-arm64",
-    "llvm-toolchain-minimal-22.1.8-linux-amd64",
-    "llvm-toolchain-minimal-22.1.8-linux-arm64",
-    "llvm-toolchain-minimal-22.1.8-windows-amd64",
-    "llvm-toolchain-minimal-22.1.8-windows-arm64",
+    "llvm-toolchain-minimal-darwin-amd64",
+    "llvm-toolchain-minimal-darwin-arm64",
+    "llvm-toolchain-minimal-linux-amd64",
+    "llvm-toolchain-minimal-linux-arm64",
+    "llvm-toolchain-minimal-windows-amd64",
+    "llvm-toolchain-minimal-windows-arm64",
 )
 
 TOOLCHAIN_EXTRAS_SHA256 = {
@@ -84,23 +96,6 @@ use_repo(
     "bsd_tar_toolchains_windows_amd64",
     "bsd_tar_toolchains_windows_arm64",
 )
-
-llvm = use_extension("//extensions:llvm.bzl", "llvm")
-llvm.version(llvm_version = LLVM_VERSION)
-llvm.configure(
-    targets = [
-        "AArch64",
-        "AMDGPU",
-        "ARM",
-        "BPF",
-        "NVPTX",
-        "RISCV",
-        "SystemZ",
-        "WebAssembly",
-        "X86",
-    ],
-)
-use_repo(llvm, "llvm-project")
 
 musl = use_extension("//runtimes/musl/extension:musl.bzl", "musl")
 use_repo(musl, "musl_libc")

--- a/e2e/llvm_version_selection/BUILD.bazel
+++ b/e2e/llvm_version_selection/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
+cc_binary(
+    name = "hello",
+    srcs = ["hello.cc"],
+)

--- a/e2e/llvm_version_selection/MODULE.bazel
+++ b/e2e/llvm_version_selection/MODULE.bazel
@@ -1,0 +1,17 @@
+module(name = "llvm_version_selection")
+
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "llvm", version = "")
+local_path_override(
+    module_name = "llvm",
+    path = "../..",
+)
+
+llvm = use_extension("@llvm//extensions:llvm.bzl", "llvm")
+llvm.version(llvm_version = "21.1.8")
+use_repo(llvm, "llvm-project")
+
+toolchain = use_extension("@llvm//extensions:toolchain.bzl", "toolchain")
+use_repo(toolchain, "llvm_toolchains")
+
+register_toolchains("@llvm_toolchains//:all")

--- a/e2e/llvm_version_selection/hello.cc
+++ b/e2e/llvm_version_selection/hello.cc
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/extensions/BUILD.bazel
+++ b/extensions/BUILD.bazel
@@ -29,6 +29,7 @@ bzl_library(
         "@bazel_tools//tools/build_defs/repo:cache.bzl",
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
+        "@llvm_version//:version",
     ],
 )
 

--- a/extensions/llvm.bzl
+++ b/extensions/llvm.bzl
@@ -138,6 +138,35 @@ def _create_support_archives():
             urls = params.urls,
         )
 
+def _llvm_version_repository_impl(rctx):
+    rctx.file("BUILD.bazel", """\
+load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "version",
+    srcs = ["version.bzl"],
+    visibility = ["//visibility:public"],
+)
+""")
+    rctx.file(
+        "version.bzl",
+        "LLVM_VERSION = {}\n".format(repr(rctx.attr.llvm_version)),
+    )
+    return rctx.repo_metadata(reproducible = True)
+
+_llvm_version_repository = repository_rule(
+    implementation = _llvm_version_repository_impl,
+    attrs = {
+        "llvm_version": attr.string(mandatory = True),
+    },
+)
+
+def _root_direct_deps(mctx):
+    for module in mctx.modules:
+        if module.is_root and module.name == "llvm":
+            return ["llvm-project", "llvm_version"]
+    return ["llvm-project"]
+
 def _get_llvm_version(mctx):
     module_selected_version = None
 
@@ -178,12 +207,16 @@ def _llvm_impl(mctx):
     llvm_version_index = _get_llvm_version_index(mctx)
     source_archive = _source_archive_for_version(llvm_version, llvm_version_index)
 
+    _llvm_version_repository(
+        name = "llvm_version",
+        llvm_version = llvm_version,
+    )
     _create_llvm_project_repository(mctx, source_archive, _get_llvm_targets(mctx))
     _create_support_archives()
 
     return mctx.extension_metadata(
         reproducible = True,
-        root_module_direct_deps = ["llvm-project"],
+        root_module_direct_deps = _root_direct_deps(mctx),
         root_module_direct_dev_deps = [],
     )
 

--- a/extensions/llvm_toolchain_minimal.bzl
+++ b/extensions/llvm_toolchain_minimal.bzl
@@ -2,6 +2,7 @@
 
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@llvm_version//:version.bzl", "LLVM_VERSION")
 
 DEFAULT_LLVM_TOOLCHAIN_MINIMAL_INDEX_FILE = "//extensions:llvm_toolchain_minimal_index.json"
 
@@ -17,16 +18,9 @@ _TARGETS = [
 def _repo_target(target):
     return target.replace("-musl", "")
 
-def _repo_name(llvm_version, target):
-    return "llvm-toolchain-minimal-{llvm_version}-{target}".format(
-        llvm_version = llvm_version,
+def _repo_name(target):
+    return "llvm-toolchain-minimal-{target}".format(
         target = _repo_target(target),
-    )
-
-def _release_key(llvm_version, suffix):
-    return "llvm-{llvm_version}{suffix}".format(
-        llvm_version = llvm_version,
-        suffix = suffix,
     )
 
 def _build_file(target):
@@ -36,37 +30,57 @@ def _build_file(target):
 
 def _get_index(module_ctx):
     index_file = Label(DEFAULT_LLVM_TOOLCHAIN_MINIMAL_INDEX_FILE)
+    dependency_index_file = None
+
     for module in module_ctx.modules:
-        for index in module.tags.index:
-            index_file = index.file
+        index_files = [index.file for index in module.tags.index]
+        if len(index_files) > 1:
+            fail("Only 1 llvm_toolchain_minimal.index(...) tag is allowed per module")
+
+        if not index_files:
+            continue
+
+        if module.is_root:
+            index_file = index_files[0]
+            break
+
+        dependency_index_file = index_files[0]
+
+    if dependency_index_file != None and index_file == Label(DEFAULT_LLVM_TOOLCHAIN_MINIMAL_INDEX_FILE):
+        index_file = dependency_index_file
 
     return json.decode(module_ctx.read(module_ctx.path(index_file)), default = None)
 
-def _release_key_for(index, llvm_version, suffix):
-    if suffix:
-        return _release_key(llvm_version, suffix)
-    return index["latest_by_llvm_version"][llvm_version]
+def _release_key(index):
+    latest_by_llvm_version = index.get("latest_by_llvm_version", {})
+    release_key = latest_by_llvm_version.get(LLVM_VERSION)
+    if release_key != None:
+        return release_key
 
-def _root_release_keys(module_ctx, index):
-    release_keys = {}
-    for module in module_ctx.modules:
-        if not module.is_root:
-            continue
+    # Keep default_prebuilt_llvm_version as the bootstrap seed when LLVM_VERSION
+    # does not have an indexed prebuilt release.
+    default_prebuilt_llvm_version = index.get("default_prebuilt_llvm_version")
+    if default_prebuilt_llvm_version == None:
+        fail("LLVM {} has no minimal prebuilt release and the index has no default_prebuilt_llvm_version".format(LLVM_VERSION))
 
-        for release in module.tags.release:
-            release_keys[release.llvm_version] = _release_key_for(index, release.llvm_version, release.suffix)
-    return release_keys
+    # buildifier: disable=print
+    print("WARNING: LLVM {} has no indexed minimal prebuilt release; using default_prebuilt_llvm_version {} as the bootstrap seed".format(
+        LLVM_VERSION,
+        default_prebuilt_llvm_version,
+    ))
 
-def _release_repo_specs(release, root_release_keys, index):
-    release_key = root_release_keys.get(release.llvm_version)
+    release_key = latest_by_llvm_version.get(default_prebuilt_llvm_version)
     if release_key == None:
-        release_key = _release_key_for(index, release.llvm_version, release.suffix)
+        fail("Default prebuilt LLVM version {} has no minimal prebuilt release".format(default_prebuilt_llvm_version))
 
+    return release_key
+
+def _release_repo_specs(index):
+    release_key = _release_key(index)
     archives = index["releases"][release_key]
     return {
-        _repo_name(release.llvm_version, target): struct(
+        _repo_name(target): struct(
             build_file = _build_file(target),
-            release_key = release_key,
             sha256 = archives[target]["sha256"],
             urls = [archives[target]["url"]],
         )
@@ -75,19 +89,7 @@ def _release_repo_specs(release, root_release_keys, index):
 
 def _llvm_toolchain_minimal_impl(module_ctx):
     index = _get_index(module_ctx)
-    repo_specs = {}
-    root_repos = {}
-    root_release_keys = _root_release_keys(module_ctx, index)
-
-    for module in module_ctx.modules:
-        for release in module.tags.release:
-            release_specs = _release_repo_specs(release, root_release_keys, index)
-            if module.is_root:
-                for repo_name in release_specs.keys():
-                    root_repos[repo_name] = True
-
-            for repo_name, spec in release_specs.items():
-                repo_specs[repo_name] = spec
+    repo_specs = _release_repo_specs(index)
 
     for repo_name, spec in repo_specs.items():
         http_archive(
@@ -101,7 +103,8 @@ def _llvm_toolchain_minimal_impl(module_ctx):
     if bazel_features.external_deps.extension_metadata_has_reproducible:
         metadata_kwargs["reproducible"] = True
 
-    root_direct_deps = sorted(root_repos.keys())
+    root_uses_extension = any([module.is_root for module in module_ctx.modules])
+    root_direct_deps = sorted(repo_specs.keys()) if root_uses_extension else []
     root_direct_dev_deps = []
     if not module_ctx.root_module_has_non_dev_dependency:
         root_direct_dev_deps = root_direct_deps
@@ -112,13 +115,6 @@ def _llvm_toolchain_minimal_impl(module_ctx):
         root_module_direct_dev_deps = root_direct_dev_deps,
         **metadata_kwargs
     )
-
-_release_tag = tag_class(
-    attrs = {
-        "llvm_version": attr.string(mandatory = True),
-        "suffix": attr.string(default = ""),
-    },
-)
 
 _index_tag = tag_class(
     attrs = {
@@ -131,9 +127,8 @@ _index_tag = tag_class(
 
 llvm_toolchain_minimal = module_extension(
     implementation = _llvm_toolchain_minimal_impl,
-    doc = "Declares llvm-toolchain-minimal prebuilt compiler repositories.",
+    doc = "Declares version-neutral minimal prebuilt compiler repositories for the LLVM version selected by llvm.",
     tag_classes = {
         "index": _index_tag,
-        "release": _release_tag,
     },
 )

--- a/extensions/llvm_toolchain_minimal_index.json
+++ b/extensions/llvm_toolchain_minimal_index.json
@@ -1,4 +1,5 @@
 {
+  "default_prebuilt_llvm_version": "22.1.8",
   "latest_by_llvm_version": {
     "21.1.8": "llvm-21.1.8-10",
     "22.1.6": "llvm-22.1.6-1",

--- a/toolchain/selects.bzl
+++ b/toolchain/selects.bzl
@@ -1,11 +1,9 @@
 load("//platforms:common.bzl", "SUPPORTED_EXECS")
 
-LLVM_VERSION = "22.1.8"
-
 def _tool_repo(exec_os, exec_cpu):
     os_part = "darwin" if exec_os == "macos" else exec_os
     cpu_part = "amd64" if exec_cpu == "x86_64" else "arm64"
-    return "@llvm-toolchain-minimal-%s-%s-%s//" % (LLVM_VERSION, os_part, cpu_part)
+    return "@llvm-toolchain-minimal-%s-%s//" % (os_part, cpu_part)
 
 def _platform_bootstrap_stage(exec_os, exec_cpu, bootstrap_stage):
     return "@llvm//platforms/config:%s_%s_%s" % (exec_os, exec_cpu, bootstrap_stage)


### PR DESCRIPTION
## Summary

The `llvm` module extension now creates an `llvm_version` repository containing the version selected by `llvm.version(...)`. The `llvm_toolchain_minimal` module extension loads that version, selects the matching release from `extensions/llvm_toolchain_minimal_index.json`, and creates six version-neutral `llvm-toolchain-minimal-<target>` repositories. This removes versioned repository names and the `llvm_toolchain_minimal.release(...)` tag from the internal and module-extension APIs.

When the selected LLVM version has no indexed minimal prebuilt, `llvm_toolchain_minimal` prints a warning and uses `default_prebuilt_llvm_version` as the stage0 bootstrap seed. This preserves bootstrap support while making the version mismatch visible.

The previous configuration selected the source version through `llvm.version(...)` while `MODULE.bazel` and `toolchain/selects.bzl` independently hard-coded the LLVM 22.1.8 minimal prebuilt repositories.

## Validation

- `bazel run --config=remote //internal_tools:buildifier.check`
- LLVM 22.1.8 and LLVM 21.1.8: `bazel build --config=remote --nobuild //toolchain/bootstrap/stage1:llvm`
- The LLVM 21.1.8 consumer test resolves `lib/clang/21` from the version-neutral minimal prebuilt repository.
- LLVM 22.1.5 prints the fallback warning, selects `default_prebuilt_llvm_version = 22.1.8`, and passes stage1 analysis.
- `bazel mod tidy` and `git diff --check`

Fixes #636
