### PR TITLE
compiler-rt: don't pass -nostdinc++ on macOS (keep the SDK libc++)

### DIFF
--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -850,8 +850,11 @@ SANITIZER_COMMON_CFLAGS = select({
     "-Wno-gnu",
     "-Wno-variadic-macros",
     "-Wno-c99-extensions",
-    "-nostdinc++",
-]
+] + select({
+    # macOS uses the SDK libc++ on the default include path; don't strip it.
+    "@platforms//os:macos": [],
+    "//conditions:default": ["-nostdinc++"],
+})
 
 # buildifier: disable=unused-variable
 SANITIZER_COMMON_LINK_FLAGS = [


### PR DESCRIPTION
## Problem

`SANITIZER_COMMON_CFLAGS` (in `3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel`) passes `-nostdinc++` unconditionally.

On macOS the toolchain's libc++ is the **SDK's**, on the default include path, and `libcxx_headers` is intentionally empty there (unlike Linux, which adds the from-source `libcxx`/`libcxxabi` headers). So `-nostdinc++` strips the C++ stdlib include path with **nothing to replace it**. The one C++ TU in `sanitizer_common` — `lib/sanitizer_common/symbolizer/sanitizer_symbolize.cpp`, which `#include <string>` — then fails:

```
sanitizer_symbolize.cpp:16:10: fatal error: 'string' file not found
```

Every sanitizer runtime (`clang_rt.asan.static`, `clang_rt.tsan.static`, …) links `sanitizer_common`'s internal symbolizer, so this blocks building **any** sanitizer runtime on macOS.

## Fix

Apply `-nostdinc++` only off macOS, where the from-source `libcxx_headers` replace the default include path. On macOS the SDK libc++ stays on the default path and the TU compiles.

```starlark
] + select({
    "@platforms//os:macos": [],
    "//conditions:default": ["-nostdinc++"],
})
```

## Test

`bazel build @llvm//runtimes/compiler-rt:clang_rt.asan.static` on darwin/arm64 (LLVM 22.1.8) now compiles past the `<string>` error.

> Note: this is necessary but not yet sufficient to build the runtimes on macOS — the same TU next fails to find LLVM's generated `Config/*.h`, because the overlay exposes LLVM's include dirs only via the private `llvm_copts`. That's orthogonal to this libc++ fix and still under investigation; this PR is the first self-contained step.