### PR TITLE
macOS sanitizers [1/5]: internal symbolizer foundation

### DIFF
--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -1267,6 +1267,11 @@ cc_library(
     implementation_deps = [
         ":libcxx_headers",
         ":sanitizers_interface_headers",
+        # sanitizer_symbolize.cpp compiles against LLVM's public headers
+        # (DIPrinter.h ...) and the generated Config/*.h. :config carries
+        # includes = ["include"] plus the generated config headers, which the
+        # overlay otherwise exposes only through the private llvm_copts.
+        "@llvm-project//llvm:config",
     ],
     includes = [
         "include",

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -1267,12 +1267,20 @@ cc_library(
     implementation_deps = [
         ":libcxx_headers",
         ":sanitizers_interface_headers",
+    ] + select({
         # sanitizer_symbolize.cpp compiles against LLVM's public headers
-        # (DIPrinter.h ...) and the generated Config/*.h. :config carries
-        # includes = ["include"] plus the generated config headers, which the
-        # overlay otherwise exposes only through the private llvm_copts.
-        "@llvm-project//llvm:config",
-    ],
+        # (DIPrinter.h ...) and the generated Config/*.h. On macOS the overlay
+        # exposes LLVM's include dirs only through the private llvm_copts, which
+        # does not propagate to dependents, so depend on :config (which carries
+        # includes = ["include"] plus the generated config headers). Other
+        # platforms already find these headers via the existing llvm deps.
+        #
+        # Keep this macOS-only: adding it everywhere fed the generated Config
+        # headers into the path-mapped compile and crashed Bazel 9 (last_rc)
+        # under --experimental_output_paths=strip on this target.
+        "@platforms//os:macos": ["@llvm-project//llvm:config"],
+        "//conditions:default": [],
+    }),
     includes = [
         "include",
         "lib",


### PR DESCRIPTION
First of a **stacked sequence (5 PRs)** that ports the compiler-rt sanitizer **runtimes** to macOS, faithfully following the upstream Darwin CMake definitions (the bar set in #6 / on #655). Builds on #655 (merged). The sequence brings ASan, LSan, TSan, UBSan. The sequence does not bring profile, xray, fuzzer, etc. But at least the doable sanitizers.

### The sequence — review/merge in order
- ✅ **#655** — don't pass `-nostdinc++` on macOS (keep the SDK libc++) — *merged*
- **[1/5] #657 (this PR)** — internal symbolizer foundation: LLVM's generated `Config/*.h`
- **[2/5] #658** — ASan as a Darwin dylib + runtime loading + sanitizer interface headers (resolves #637)
- **[3/5] #659** — UBSan + LSan dylibs
- **[4/5] #660** — TSan dylib (build/link; runtime follow-up)
- **[5/5] #661** — run the macOS sanitizer e2e suite in CI

Each branch is stacked on the previous. Because the intermediate branches aren't in this repo, GitHub shows each PR's diff against `main` (cumulative) — review the **tip commit(s)** of each PR; the diffs shrink as earlier PRs merge.

Darwin specifics handled across the chain (matching upstream): sanitizers ship as `.dylib`s (asan/ubsan/lsan/tsan) named `libclang_rt.<name>_osx_dynamic.dylib` with `@rpath` install_names, weak-symbol `-Wl,-U` flags, SDK libc++, `-resource-dir` on macOS, and runtime loading via `dynamic_deps`; runtimes upstream doesn't build on Darwin (msan/dfsan/hwasan/safestack/scudo/...) are intentionally absent.

### This PR
`sanitizer_symbolize.cpp` compiles against LLVM's public headers and the generated `Config/*.h`. The overlay exposes LLVM's include dirs only through the private `llvm_copts`, which doesn't propagate to dependents, so the TU failed to find `Config/*.h`. Depend on `@llvm-project//llvm:config` (public `includes` + generated config headers).

Together with #655 this is what the internal symbolizer needs to compile on macOS, completing the `sanitizer_common` foundation that every sanitizer runtime links against (#637).

Verified on darwin/arm64: `sanitizer_common`, the internal symbolizer, and `interception` build.
