### PR TITLE
macOS sanitizers [2/5]: ASan dylib + runtime loading + interface headers

### DIFF
--- a/3rd_party/llvm-project/x.x/compiler-rt/BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/BUILD.bazel
@@ -20,3 +20,13 @@ bzl_library(
     srcs = ["filter_builtin_sources.bzl"],
     visibility = ["//visibility:public"],
 )
+
+bzl_library(
+    name = "weak_symbols",
+    srcs = ["weak_symbols.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_skylib//rules:diff_test",
+        "@bazel_skylib//rules:write_file",
+    ],
+)

--- a/3rd_party/llvm-project/x.x/compiler-rt/BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/BUILD.bazel
@@ -16,12 +16,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "filter_builtin_sources",
-    srcs = ["filter_builtin_sources.bzl"],
-    visibility = ["//visibility:public"],
-)
-
-bzl_library(
     name = "weak_symbols",
     srcs = ["weak_symbols.bzl"],
     visibility = ["//visibility:public"],
@@ -29,4 +23,10 @@ bzl_library(
         "@bazel_skylib//rules:diff_test",
         "@bazel_skylib//rules:write_file",
     ],
+)
+
+bzl_library(
+    name = "filter_builtin_sources",
+    srcs = ["filter_builtin_sources.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -4,6 +4,15 @@ load("@llvm//:directory.bzl", "headers_directory")
 load("@llvm//:sh_script.bzl", "sh_script")
 load("@llvm//3rd_party/llvm-project/x.x/compiler-rt:filter_builtin_sources.bzl", "filter_builtin_sources")
 load("@llvm//3rd_party/llvm-project/x.x/compiler-rt:targets.bzl", "atomic_helper_cc_library")
+load(
+    "@llvm//3rd_party/llvm-project/x.x/compiler-rt:weak_symbols.bzl",
+    "ASAN_WEAK_SYMBOLS",
+    "LSAN_WEAK_SYMBOLS",
+    "SANITIZER_COMMON_WEAK_SYMBOLS",
+    "UBSAN_WEAK_SYMBOLS",
+    "XRAY_WEAK_SYMBOLS",
+    "weak_symbol_link_flags",
+)
 load("@llvm//toolchain/args:llvm_target_triple.bzl", "LLVM_TARGET_TRIPLE")
 load("@llvm//toolchain/runtimes:cc_runtime_shared_library.bzl", "cc_runtime_stage0_shared_library")
 load("@llvm//toolchain/runtimes:cc_runtime_static_library.bzl", "cc_runtime_stage0_static_library")
@@ -3115,7 +3124,11 @@ cc_runtime_stage0_shared_library(
         ],
         "//conditions:default": [],
     }),
-    shared_lib_name = "libasan.shared.so",
+    shared_lib_name = select({
+        # Darwin ships asan as a dylib named libclang_rt.asan_osx_dynamic.dylib.
+        "@platforms//os:macos": "libclang_rt.asan_osx_dynamic.dylib",
+        "//conditions:default": "libasan.shared.so",
+    }),
     user_link_flags = select({
         "@llvm//platforms/config:gnu": [
             "-L$(location @llvm//runtimes/glibc:glibc_library_search_directory)",
@@ -3125,6 +3138,24 @@ cc_runtime_stage0_shared_library(
             "-L$(location @llvm//runtimes/musl:musl_library_search_directory)",
             "-lc",
         ],
+        "//conditions:default": [],
+    }) + select({
+        # Darwin: the asan runtime is a dylib loaded via @rpath (the Clang
+        # driver adds -rpath at link time), built against the SDK libc++.
+        # See lib/asan/CMakeLists.txt (APPLE branch) and DARWIN_COMMON_LINK_FLAGS
+        # in cmake/base-config-ix.cmake.
+        "@platforms//os:macos": [
+            "-Wl,-install_name,@rpath/libclang_rt.asan_osx_dynamic.dylib",
+            "-stdlib=libc++",
+            "-lc++",
+            "-lc++abi",
+        ] + weak_symbol_link_flags([
+            ASAN_WEAK_SYMBOLS,
+            LSAN_WEAK_SYMBOLS,
+            UBSAN_WEAK_SYMBOLS,
+            SANITIZER_COMMON_WEAK_SYMBOLS,
+            XRAY_WEAK_SYMBOLS,
+        ]),
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -1267,6 +1267,11 @@ cc_library(
     implementation_deps = [
         ":libcxx_headers",
         ":sanitizers_interface_headers",
+        # sanitizer_symbolize.cpp compiles against LLVM's public headers
+        # (DIPrinter.h ...) and the generated Config/*.h. :config carries
+        # includes = ["include"] plus the generated config headers, which the
+        # overlay otherwise exposes only through the private llvm_copts.
+        "@llvm-project//llvm:config",
     ],
     includes = [
         "include",

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -12,6 +12,7 @@ load(
     "UBSAN_WEAK_SYMBOLS",
     "XRAY_WEAK_SYMBOLS",
     "weak_symbol_link_flags",
+    "weak_symbols_in_sync_tests",
 )
 load("@llvm//toolchain/args:llvm_target_triple.bzl", "LLVM_TARGET_TRIPLE")
 load("@llvm//toolchain/runtimes:cc_runtime_shared_library.bzl", "cc_runtime_stage0_shared_library")
@@ -20,6 +21,10 @@ load("@llvm//toolchain/runtimes:cc_stage0_object.bzl", "cc_stage0_object")
 load("@llvm//toolchain/runtimes:cc_unsanitized_library.bzl", "cc_unsanitized_library")
 load("@llvm-project//:vars.bzl", "LLVM_VERSION_MAJOR")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+# diff_tests asserting the weak-symbol lists in weak_symbols.bzl stay in sync
+# with upstream's compiler-rt/lib/<name>/weak_symbols.txt (run on any platform).
+weak_symbols_in_sync_tests()
 
 filegroup(
     name = "asan_ignorelist",

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -1267,12 +1267,20 @@ cc_library(
     implementation_deps = [
         ":libcxx_headers",
         ":sanitizers_interface_headers",
+    ] + select({
         # sanitizer_symbolize.cpp compiles against LLVM's public headers
-        # (DIPrinter.h ...) and the generated Config/*.h. :config carries
-        # includes = ["include"] plus the generated config headers, which the
-        # overlay otherwise exposes only through the private llvm_copts.
-        "@llvm-project//llvm:config",
-    ],
+        # (DIPrinter.h ...) and the generated Config/*.h. On macOS the overlay
+        # exposes LLVM's include dirs only through the private llvm_copts, which
+        # does not propagate to dependents, so depend on :config (which carries
+        # includes = ["include"] plus the generated config headers). Other
+        # platforms already find these headers via the existing llvm deps.
+        #
+        # Keep this macOS-only: adding it everywhere fed the generated Config
+        # headers into the path-mapped compile and crashed Bazel 9 (last_rc)
+        # under --experimental_output_paths=strip on this target.
+        "@platforms//os:macos": ["@llvm-project//llvm:config"],
+        "//conditions:default": [],
+    }),
     includes = [
         "include",
         "lib",

--- a/3rd_party/llvm-project/x.x/compiler-rt/weak_symbols.bzl
+++ b/3rd_party/llvm-project/x.x/compiler-rt/weak_symbols.bzl
@@ -1,0 +1,82 @@
+"""Darwin weak/undefined symbol link flags for compiler-rt runtimes.
+
+On Darwin the sanitizer runtimes are linked with `-Wl,-U,<symbol>` for each
+symbol listed in `compiler-rt/lib/<name>/weak_symbols.txt`, so that programs may
+override them at runtime (for example `__asan_default_options`). This mirrors
+`add_weak_symbols()` in `compiler-rt/cmake/Modules/SanitizerUtils.cmake`, which
+emits `-Wl,-U,${symbol}` per symbol. The symbol names are kept verbatim from the
+`weak_symbols.txt` files (Mach-O leading-underscore form).
+"""
+
+# compiler-rt/lib/sanitizer_common/weak_symbols.txt
+SANITIZER_COMMON_WEAK_SYMBOLS = [
+    "___sanitizer_free_hook",
+    "___sanitizer_get_dtls_size",
+    "___sanitizer_malloc_hook",
+    "___sanitizer_report_error_summary",
+    "___sanitizer_sandbox_on_notify",
+    "___sanitizer_symbolize_code",
+    "___sanitizer_symbolize_data",
+    "___sanitizer_symbolize_frame",
+    "___sanitizer_symbolize_demangle",
+    "___sanitizer_symbolize_flush",
+    "___sanitizer_symbolize_set_demangle",
+    "___sanitizer_symbolize_set_inline_frames",
+    "__dyld_get_dyld_header",
+]
+
+# compiler-rt/lib/asan/weak_symbols.txt
+ASAN_WEAK_SYMBOLS = [
+    "___asan_default_options",
+    "___asan_default_suppressions",
+    "___asan_on_error",
+    "___asan_set_shadow_00",
+    "___asan_set_shadow_01",
+    "___asan_set_shadow_02",
+    "___asan_set_shadow_03",
+    "___asan_set_shadow_04",
+    "___asan_set_shadow_05",
+    "___asan_set_shadow_06",
+    "___asan_set_shadow_07",
+    "___asan_set_shadow_f1",
+    "___asan_set_shadow_f2",
+    "___asan_set_shadow_f3",
+    "___asan_set_shadow_f4",
+    "___asan_set_shadow_f5",
+    "___asan_set_shadow_f6",
+    "___asan_set_shadow_f7",
+    "___asan_set_shadow_f8",
+]
+
+# compiler-rt/lib/lsan/weak_symbols.txt
+LSAN_WEAK_SYMBOLS = [
+    "___lsan_default_options",
+    "___lsan_default_suppressions",
+    "___lsan_is_turned_off",
+]
+
+# compiler-rt/lib/ubsan/weak_symbols.txt
+UBSAN_WEAK_SYMBOLS = [
+    "___ubsan_default_options",
+]
+
+# compiler-rt/lib/xray/weak_symbols.txt
+XRAY_WEAK_SYMBOLS = [
+    "___start_xray_fn_idx",
+    "___start_xray_instr_map",
+    "___stop_xray_fn_idx",
+    "___stop_xray_instr_map",
+    "___xray_default_options",
+]
+
+def weak_symbol_link_flags(symbol_lists):
+    """Returns `-Wl,-U,<symbol>` link flags for the given lists of weak symbols.
+
+    Args:
+      symbol_lists: a list of symbol-name lists (e.g. [ASAN_WEAK_SYMBOLS, ...]).
+    """
+    return [
+        "-Wl,-U,{}".format(symbol)
+        for symbols in symbol_lists
+        for symbol in symbols
+    ]

--- a/3rd_party/llvm-project/x.x/compiler-rt/weak_symbols.bzl
+++ b/3rd_party/llvm-project/x.x/compiler-rt/weak_symbols.bzl
@@ -6,7 +6,13 @@ override them at runtime (for example `__asan_default_options`). This mirrors
 `add_weak_symbols()` in `compiler-rt/cmake/Modules/SanitizerUtils.cmake`, which
 emits `-Wl,-U,${symbol}` per symbol. The symbol names are kept verbatim from the
 `weak_symbols.txt` files (Mach-O leading-underscore form).
+
+`weak_symbols_in_sync_tests()` guards these lists against drift from upstream
+on LLVM version bumps.
 """
+
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 # compiler-rt/lib/sanitizer_common/weak_symbols.txt
 SANITIZER_COMMON_WEAK_SYMBOLS = [
@@ -80,3 +86,40 @@ def weak_symbol_link_flags(symbol_lists):
         for symbols in symbol_lists
         for symbol in symbols
     ]
+
+# Maps each runtime to (its weak-symbol list, the upstream weak_symbols.txt
+# under compiler-rt/lib/). Used by weak_symbols_in_sync_tests().
+_WEAK_SYMBOLS_BY_RUNTIME = {
+    "asan": ASAN_WEAK_SYMBOLS,
+    "lsan": LSAN_WEAK_SYMBOLS,
+    "sanitizer_common": SANITIZER_COMMON_WEAK_SYMBOLS,
+    "ubsan": UBSAN_WEAK_SYMBOLS,
+    "xray": XRAY_WEAK_SYMBOLS,
+}
+
+def weak_symbols_in_sync_tests():
+    """Asserts each *_WEAK_SYMBOLS list matches upstream lib/<name>/weak_symbols.txt.
+
+    The lists above are a verbatim copy of compiler-rt's weak_symbols.txt files;
+    these diff_tests fail if they drift (e.g. after an LLVM version bump), so the
+    lists must be updated to match upstream. Must be called from the compiler-rt
+    overlay package (the one that owns lib/<name>/weak_symbols.txt).
+    """
+    for name, symbols in _WEAK_SYMBOLS_BY_RUNTIME.items():
+        write_file(
+            name = "_{}_weak_symbols_expected".format(name),
+            out = "_{}_weak_symbols.expected.txt".format(name),
+            # Trailing "" reproduces the file's final newline so the exact
+            # diff_test matches lib/<name>/weak_symbols.txt.
+            content = symbols + [""],
+            newline = "unix",
+        )
+        diff_test(
+            name = "{}_weak_symbols_in_sync_test".format(name),
+            failure_message = (
+                "weak_symbols.bzl {}_WEAK_SYMBOLS is out of sync with ".format(name.upper()) +
+                "lib/{}/weak_symbols.txt; update it to match upstream.".format(name)
+            ),
+            file1 = "_{}_weak_symbols.expected.txt".format(name),
+            file2 = "lib/{}/weak_symbols.txt".format(name),
+        )

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -705,11 +705,23 @@ exec_test(
 asan_cc_binary(
     name = "asan_fail",
     srcs = ["asan_fail.cc"],
-    linkopts = [
-        "-Wl,--icf=none",
-    ],
+    # On macOS the ASan runtime is a dylib (libclang_rt.asan_osx_dynamic.dylib).
+    # Declaring it as a dynamic_dep puts it in the binary's runfiles and gives
+    # the binary an @loader_path rpath (via the runtime_library_search_directories
+    # feature), so dyld can load it at run time. On Linux the static runtime is
+    # linked into the binary, so no dynamic_dep is needed.
+    dynamic_deps = select({
+        "@platforms//os:macos": ["@llvm//runtimes/compiler-rt:clang_rt.asan.shared"],
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        # --icf is an ld.lld (ELF) flag; ld64.lld on macOS does not accept it.
+        "@platforms//os:linux": ["-Wl,--icf=none"],
+        "//conditions:default": [],
+    }),
     target_compatible_with = select({
         "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
 )

--- a/e2e/rules_cc/asan_output_test.sh
+++ b/e2e/rules_cc/asan_output_test.sh
@@ -3,11 +3,6 @@ set -euo pipefail
 
 EXPECTED_OUTPUT="ERROR: AddressSanitizer: heap-use-after-free on address"
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  echo "Skipping ASan runtime check on Darwin; runtime is only provided for Linux."
-  exit 0
-fi
-
 BIN="$BINARY"
 if [[ ! -x "$BIN" && -n "${RUNFILES_DIR:-}" ]]; then
   if [[ -x "${RUNFILES_DIR}/${BIN}" ]]; then

--- a/runtimes/BUILD.bazel
+++ b/runtimes/BUILD.bazel
@@ -170,13 +170,6 @@ alias(
 
 copy_to_resource_directory(
     name = "resource_directory_default",
-    # macOS uses :resource_directory_macos instead: the Darwin runtime naming
-    # differs (libclang_rt.<name>_osx[_dynamic]) and only a subset of runtimes
-    # is supported upstream. See the :resource_directory alias below.
-    target_compatible_with = select({
-        "@platforms//os:macos": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
     srcs = select({
         "//platforms/config:none_bpfeb": {},
         "//platforms/config:none_bpfel": {},
@@ -265,6 +258,13 @@ copy_to_resource_directory(
             "//runtimes/compiler-rt:clang_rt.xray_basic.static": "libclang_rt.xray-basic",
         },
         "//conditions:default": {},
+    }),
+    # macOS uses :resource_directory_macos instead: the Darwin runtime naming
+    # differs (libclang_rt.<name>_osx[_dynamic]) and only a subset of runtimes
+    # is supported upstream. See the :resource_directory alias below.
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
 )

--- a/runtimes/BUILD.bazel
+++ b/runtimes/BUILD.bazel
@@ -169,7 +169,14 @@ alias(
 )
 
 copy_to_resource_directory(
-    name = "resource_directory",
+    name = "resource_directory_default",
+    # macOS uses :resource_directory_macos instead: the Darwin runtime naming
+    # differs (libclang_rt.<name>_osx[_dynamic]) and only a subset of runtimes
+    # is supported upstream. See the :resource_directory alias below.
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     srcs = select({
         "//platforms/config:none_bpfeb": {},
         "//platforms/config:none_bpfel": {},
@@ -258,6 +265,37 @@ copy_to_resource_directory(
             "//runtimes/compiler-rt:clang_rt.xray_basic.static": "libclang_rt.xray-basic",
         },
         "//conditions:default": {},
+    }),
+    visibility = ["//visibility:public"],
+)
+
+# Darwin resource directory. Upstream compiler-rt supports only a subset of
+# runtimes on macOS, with different library names (libclang_rt.<name>_osx for
+# static archives, libclang_rt.<name>_osx_dynamic.dylib for shared runtimes).
+# Runtimes that upstream does not build on Darwin (msan, dfsan, hwasan,
+# safestack, scudo, gwp_asan, cfi, nsan, rtsan, tysan) are intentionally absent.
+copy_to_resource_directory(
+    name = "resource_directory_macos",
+    srcs = select({
+        "//config:asan_enabled": {
+            # asan ships as a dylib on Darwin (no static standalone runtime);
+            # asan_cxx is folded into the dylib. The asan_static archive carries
+            # the always-statically-linked portion.
+            "//runtimes/compiler-rt:clang_rt.asan.shared": "libclang_rt.asan_osx_dynamic",
+            "//runtimes/compiler-rt:clang_rt.asan_static.static": "libclang_rt.asan_static_osx",
+        },
+        "//conditions:default": {},
+    }),
+    target_compatible_with = ["@platforms//os:macos"],
+    target_triple = "darwin",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "resource_directory",
+    actual = select({
+        "@platforms//os:macos": ":resource_directory_macos",
+        "//conditions:default": ":resource_directory_default",
     }),
     visibility = ["//visibility:public"],
 )

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -154,7 +154,10 @@ cc_args_list(
 cc_args_list(
     name = "resource_dir",
     args = select({
-        "@platforms//os:macos": [],
+        # macOS now ships compiler-rt sanitizer runtimes (e.g. the asan dylib)
+        # in the resource directory, so the Clang driver needs -resource-dir to
+        # find them when linking (e.g. -fsanitize=address). This is a link-only
+        # arg, so it does not affect builtin-header resolution at compile time.
         "//conditions:default": [
             "//toolchain/args:resource_dir",
         ],

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -269,7 +269,14 @@ cc_args_list(
     args = [
         "//toolchain/args/macos:macos_minimum_os_flags",
         "//toolchain/args/macos:macos_default_framework_flags",
-    ],
+    ] + select({
+        # Only expose the sanitizer interface headers when compiling user
+        # programs (runtime_stage=complete), not when building the compiler-rt
+        # runtimes themselves (stage0). Those already include compiler-rt/include
+        # directly, and adding it again collides in the macOS sandbox.
+        ":runtimes_all": ["//toolchain/args/macos:sanitizer_headers_include_search_paths"],
+        "//conditions:default": [],
+    }),
 )
 
 # TODO(cerisier): extract those into proper semantic args list.

--- a/toolchain/args/macos/BUILD.bazel
+++ b/toolchain/args/macos/BUILD.bazel
@@ -45,6 +45,40 @@ cc_args(
     ],
 )
 
+# Make compiler-rt's public sanitizer interface headers (sanitizer/*.h)
+# available when compiling instrumented user code (e.g. abseil's
+# <sanitizer/common_interface_defs.h>). Mirrors
+# //toolchain/args/linux:sanitizer_headers_include_search_paths.
+#
+# This is only added for user-program (runtime_stage=complete) builds, never
+# when building the compiler-rt runtimes themselves: those already pull in
+# compiler-rt/include via includes=["include"], and on macOS the copy-based
+# sandbox rejects staging that directory twice ("File exists"). See
+# macos_toolchain_args in //toolchain:BUILD.bazel.
+cc_args(
+    name = "sanitizer_headers_include_search_paths",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:source_compile_actions",
+    ],
+    allowlist_include_directories = [
+        "//sanitizers:sanitizers_headers_include_search_directory",
+    ],
+    # Make sure these sanitizer paths come after any user supplied paths, which
+    # might also include another version of llvm's sanitizer headers.
+    args = [
+        "-Xclang",
+        "-internal-isystem",
+        "-Xclang",
+        "{sanitizer_headers_include_search_paths}",
+    ],
+    data = [
+        "//sanitizers:sanitizers_headers_include_search_directory",
+    ],
+    format = {
+        "sanitizer_headers_include_search_paths": "//sanitizers:sanitizers_headers_include_search_directory",
+    },
+)
+
 # TODO(cerisier): Extract those into proper semantic args list.
 cc_args(
     name = "default_link_flags",


### PR DESCRIPTION
**Part 2 of 4** of the macOS compiler-rt sanitizer port — stacked on the foundation PR #657. Resolves #637 (ASan on macOS).

> Diff is cumulative against `main`; the commits new to this PR are the three ASan/toolchain commits at the tip. Review/merge after #657.

On Darwin, ASan ships as `libclang_rt.asan_osx_dynamic.dylib` (a dylib, no static standalone), resolved by the Clang driver from `<resource-dir>/lib/darwin`. This wires it up faithfully (see `lib/asan/CMakeLists.txt` APPLE branch):

- `asan.shared` emits `libclang_rt.asan_osx_dynamic.dylib` with `install_name @rpath/...`, the Darwin link flags (`-stdlib=libc++ -lc++ -lc++abi`) and the `-Wl,-U` weak-symbol flags (asan/lsan/ubsan/sanitizer_common/xray, mirrored in `weak_symbols.bzl`).
- `runtimes:resource_directory` splits into a macOS variant (Darwin `_osx`/`_osx_dynamic` names; only the Darwin-supported runtimes) and the existing default, chosen by an alias; `-resource-dir` is enabled on macOS (link-only).
- The sanitizer interface headers (`sanitizer/*.h`) are wired into the macOS toolchain for user programs (gated to `runtime_stage=complete` to avoid a stage0 sandbox collision) — fixes `'sanitizer/common_interface_defs.h' file not found` from instrumented deps like abseil.
- The asan e2e binary loads the dylib at run time via `dynamic_deps`.

Verified on darwin/arm64: a program including `<sanitizer/common_interface_defs.h>` compiles, links, loads the dylib, and ASan reports `heap-use-after-free`.
