### PR TITLE
Add shared (DSO) AddressSanitizer/ThreadSanitizer runtimes

### DIFF
--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -2304,6 +2304,114 @@ cc_runtime_stage0_static_library(
     ],
 )
 
+# The static tsan library is compiled -fPIE, the shared runtime is compiled -fPIC.
+TSAN_RTL_CFLAGS_PIC = SANITIZER_COMMON_CFLAGS + [
+    "-fno-rtti",
+    "-fPIC",
+]
+
+cc_library(
+    name = "tsan_pic",
+    srcs = [
+        "lib/builtins/assembly.h",
+        ":tsan_preinit_sources",
+        ":tsan_rtl_headers",
+        ":tsan_rtl_sources",
+        ":ubsan_headers",
+    ],
+    copts = TSAN_RTL_CFLAGS_PIC,
+    implementation_deps = [
+        ":interception_impl_headers",
+        ":libcxx_headers",
+        ":sanitizer_impl_headers",
+    ],
+    includes = ["lib"],
+    textual_hdrs = [
+        "lib/tsan/rtl/tsan_flags.inc",
+        "lib/tsan/rtl/tsan_interface.inc",
+    ],
+)
+
+cc_library(
+    name = "tsan_cxx_pic",
+    srcs = [
+        ":tsan_rtl_cxx_sources",
+        ":tsan_rtl_headers",
+        ":ubsan_headers",
+    ],
+    copts = TSAN_RTL_CFLAGS_PIC,
+    implementation_deps = [
+        ":interception_impl_headers",
+        ":libcxx_headers",
+        ":sanitizer_impl_headers",
+    ],
+    includes = ["lib"],
+    textual_hdrs = [
+        "lib/tsan/rtl/tsan_flags.inc",
+        "lib/tsan/rtl/tsan_interface.inc",
+    ],
+)
+
+# Drops :sanitizer_common_symbolizer_internal; the DSO symbolizes via external llvm-symbolizer.
+cc_library(
+    name = "tsan_common_runtime",
+    deps = [
+        ":interception",
+        ":sanitizer_common",
+        ":sanitizer_common_coverage",
+        ":sanitizer_common_libc",
+        ":sanitizer_common_symbolizer",
+        ":ubsan_no_standalone",
+    ],
+)
+
+cc_library(
+    name = "tsan_dynamic",
+    deps = [
+        ":tsan_cxx_pic",
+        ":tsan_pic",
+    ],
+)
+
+cc_runtime_stage0_shared_library(
+    name = "tsan.shared",
+    additional_linker_inputs = select({
+        "@llvm//platforms/config:gnu": [
+            "@llvm//runtimes/glibc:glibc_library_search_directory",
+        ],
+        "@llvm//platforms/config:musl": [
+            "@llvm//runtimes/musl:musl_library_search_directory",
+        ],
+        "//conditions:default": [],
+    }),
+    shared_lib_name = "libclang_rt.tsan.so",
+    user_link_flags = select({
+        "@llvm//platforms/config:gnu": [
+            "-L$(location @llvm//runtimes/glibc:glibc_library_search_directory)",
+            "-lc",
+            "-ldl",
+            "-lm",
+            "-lpthread",
+            "-Wl,--allow-multiple-definition",
+        ],
+        "@llvm//platforms/config:musl": [
+            "-L$(location @llvm//runtimes/musl:musl_library_search_directory)",
+            "-lc",
+        ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        # builtins + libcxxabi + libunwind supply __gcc_personality_v0 /
+        # __gxx_personality_v0 / _Unwind_* for the DSO.
+        ":builtins",
+        ":tsan_common_runtime",
+        ":tsan_dynamic",
+        "@llvm-project//libcxxabi:libcxxabi",
+        "@llvm-project//libunwind:libunwind",
+    ],
+)
+
 ###
 ### compile-rt/lib/lsan/CMakeLists.txt.
 ###
@@ -2963,12 +3071,10 @@ ASAN_CFLAGS = SANITIZER_COMMON_CFLAGS + [
     "-Wno-format",
 ]
 
-# buildifier: disable=unused-variable
 ASAN_DYNAMIC_CFLAGS = [
     "-ftls-model=initial-exec",
 ]
 
-# buildifier: disable=unused-variable
 ASAN_DYNAMIC_COMMON_DEFINITIONS = [
     "ASAN_DYNAMIC=1",
 ]
@@ -3081,6 +3187,116 @@ cc_library(
     ],
 )
 
+# Forks of :asan / :lsan_common / :asan_common_runtime that drop
+# :sanitizer_common_symbolizer_internal (the in-process LLVM symbolizer) from the
+# DSO; it symbolizes via external llvm-symbolizer. The originals keep it for the
+# static runtimes (asan.static, lsan.static).
+cc_library(
+    name = "lsan_common_dynamic",
+    srcs = [
+        ":lsan_common_sources",
+        ":lsan_headers",
+    ],
+    copts = LSAN_CFLAGS,
+    implementation_deps = [
+        ":libcxx_headers",
+    ],
+    includes = ["lib"],
+    textual_hdrs = [
+        "lib/lsan/lsan_flags.inc",
+    ],
+    deps = [
+        ":sanitizer_common",
+        ":sanitizer_common_coverage",
+        ":sanitizer_common_libc",
+        ":sanitizer_common_symbolizer",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
+    name = "asan_dynamic_runtime",
+    copts = ASAN_CFLAGS,
+    deps = [
+        ":interception",
+        ":lsan_common_dynamic",
+        ":sanitizer_common",
+        ":sanitizer_common_coverage",
+        ":sanitizer_common_libc",
+        ":sanitizer_common_symbolizer",
+        ":ubsan_no_standalone",
+    ],
+)
+
+cc_library(
+    name = "asan_no_internal_symbolizer",
+    srcs = [
+        ":asan_headers",
+        ":asan_sources",
+        ":ubsan_headers",
+    ],
+    copts = [
+        # The AddressSanitizer run-time should not be instrumented by AddressSanitizer.
+        "-fno-sanitize=address",
+    ] + select({
+        # Upstream adds these via SANITIZER_COMMON_CFLAGS for all supported platforms.
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-fPIC",
+            "-fvisibility=hidden",
+            "-fvisibility-inlines-hidden",
+        ],
+    }) + ASAN_DYNAMIC_CFLAGS,
+    implementation_deps = [
+        ":interception_impl_headers",
+        ":libcxx_headers",
+        ":lsan_common_headers",
+        ":sanitizer_impl_headers",
+    ],
+    includes = ["lib"],
+    # ASAN_DYNAMIC=1; without it the DSO fails asan's "incompatible ASan runtimes" check at load.
+    local_defines = ASAN_DYNAMIC_COMMON_DEFINITIONS,
+    textual_hdrs = [
+        "lib/asan/asan_activation_flags.inc",
+        "lib/asan/asan_flags.inc",
+        "lib/asan/asan_interface.inc",
+        ":sanitizer_common_interceptors_vfork_sources",
+    ],
+    deps = [
+        ":interception",
+        ":lsan_common_dynamic",
+        ":sanitizer_common",
+        ":sanitizer_common_coverage",
+        ":sanitizer_common_libc",
+        ":sanitizer_common_symbolizer",
+    ],
+)
+
+cc_library(
+    name = "asan_cxx_dynamic",
+    srcs = [
+        ":asan_cxx_sources",
+        ":asan_headers",
+    ],
+    copts = ASAN_CFLAGS + ASAN_DYNAMIC_CFLAGS,
+    implementation_deps = [
+        ":libcxx_headers",
+    ],
+    local_defines = ASAN_DYNAMIC_COMMON_DEFINITIONS,
+    deps = [
+        ":interception_impl_headers",
+        ":sanitizer_impl_headers",
+    ],
+)
+
+cc_library(
+    name = "asan_dynamic_shared",
+    deps = [
+        ":asan_cxx_dynamic",
+        ":asan_no_internal_symbolizer",
+    ],
+)
+
 ##
 
 cc_runtime_stage0_static_library(
@@ -3132,12 +3348,17 @@ cc_runtime_stage0_shared_library(
     shared_lib_name = select({
         # Darwin ships asan as a dylib named libclang_rt.asan_osx_dynamic.dylib.
         "@platforms//os:macos": "libclang_rt.asan_osx_dynamic.dylib",
-        "//conditions:default": "libasan.shared.so",
+        "//conditions:default": "libclang_rt.asan.so",
     }),
     user_link_flags = select({
         "@llvm//platforms/config:gnu": [
             "-L$(location @llvm//runtimes/glibc:glibc_library_search_directory)",
             "-lc",
+            "-ldl",
+            "-lm",
+            "-lpthread",
+            "-lrt",
+            "-Wl,--allow-multiple-definition",
         ],
         "@llvm//platforms/config:musl": [
             "-L$(location @llvm//runtimes/musl:musl_library_search_directory)",
@@ -3165,7 +3386,10 @@ cc_runtime_stage0_shared_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        ":asan_common_runtime",
-        ":asan_dynamic",
+        # libcxxabi/libunwind supply __gxx_personality_v0 / _Unwind_* for the DSO.
+        ":asan_dynamic_runtime",
+        ":asan_dynamic_shared",
+        "@llvm-project//libcxxabi:libcxxabi",
+        "@llvm-project//libunwind:libunwind",
     ],
 )

--- a/3rd_party/llvm-project/x.x/libcxxabi/libcxxabi.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libcxxabi/libcxxabi.BUILD.bazel
@@ -158,6 +158,8 @@ cc_library(
         "src/**/*.h",
         "src/**/*.def",
     ]),
+    # Public so the shared compiler-rt runtimes can satisfy __gxx_personality_v0.
+    visibility = ["//visibility:public"],
 )
 
 cc_runtime_stage0_static_library(

--- a/config/defs.bzl
+++ b/config/defs.bzl
@@ -154,3 +154,25 @@ def config_settings():
             build_setting_default = False,
         )
         _declare_sanitizer_config_setting(sanitizer)
+
+    # Opt-in: link the shared (DSO) sanitizer runtimes instead of the static archives.
+    bool_flag(
+        name = "shared_sanitizer",
+        build_setting_default = False,
+    )
+    native.config_setting(
+        name = "shared_sanitizer_enabled",
+        flag_values = {
+            ":shared_sanitizer": "true",
+        },
+    )
+
+    # True when the sanitizer is enabled and shared linking is opted in.
+    for sanitizer in ["asan", "tsan"]:
+        selects.config_setting_group(
+            name = sanitizer + "_shared_enabled",
+            match_all = [
+                ":{}_enabled".format(sanitizer),
+                ":shared_sanitizer_enabled",
+            ],
+        )

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_binary", "platform_transition_filegroup")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@llvm//:defs.bzl", "exec_test")
 load("@llvm//3rd_party/gcc:version.bzl", "DEFAULT_GCC_VERSION", "libstdcxx_constraint_value")
@@ -15,6 +16,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(
     "//:defs.bzl",
     "asan_cc_binary",
+    "asan_shared_cc_binary",
     "cfi_cc_binary",
     "dfsan_cc_binary",
     "fission_cc_binary",
@@ -28,6 +30,7 @@ load(
     "rtsan_cc_binary",
     "safestack_cc_binary",
     "tsan_cc_binary",
+    "tsan_shared_cc_binary",
     "tysan_cc_binary",
     "ubsan_cc_binary",
     "xray_cc_binary",
@@ -732,6 +735,149 @@ exec_test(
     data = [":asan_fail"],
     env = {"BINARY": "$(rootpath :asan_fail)"},
     rule = sh_test,
+)
+
+# Shared (DSO) sanitizer runtime tests (--@llvm//config:shared_sanitizer).
+
+_LINUX_ONLY = select({
+    "@platforms//os:linux": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
+_LINUX_X86_64_ONLY = select({
+    "@llvm//platforms/config:linux_x86_64": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+})
+
+asan_shared_cc_binary(
+    name = "asan_shared_fail",
+    srcs = ["asan_fail.cc"],
+    linkopts = [
+        "-Wl,--icf=none",
+    ],
+    target_compatible_with = _LINUX_ONLY,
+)
+
+tsan_shared_cc_binary(
+    name = "tsan_shared_fail",
+    srcs = ["tsan_fail.cc"],
+    target_compatible_with = _LINUX_X86_64_ONLY,
+)
+
+# End-to-end: the shared-runtime binary loads the DSO and the sanitizer fires.
+exec_test(
+    name = "asan_shared_output_test",
+    srcs = ["asan_shared_output_test.sh"],
+    data = [
+        ":asan_shared_fail",
+        "@llvm//runtimes/compiler-rt:clang_rt.asan.shared",
+    ],
+    env = {
+        "BINARY": "$(rlocationpath :asan_shared_fail)",
+        "DSO": "$(rlocationpath @llvm//runtimes/compiler-rt:clang_rt.asan.shared)",
+    },
+    rule = sh_test,
+    target_compatible_with = _LINUX_ONLY,
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+exec_test(
+    name = "tsan_shared_output_test",
+    srcs = ["tsan_shared_output_test.sh"],
+    data = [
+        ":tsan_shared_fail",
+        "@llvm//runtimes/compiler-rt:clang_rt.tsan.shared",
+    ],
+    env = {
+        "BINARY": "$(rlocationpath :tsan_shared_fail)",
+        "DSO": "$(rlocationpath @llvm//runtimes/compiler-rt:clang_rt.tsan.shared)",
+    },
+    rule = sh_test,
+    target_compatible_with = _LINUX_X86_64_ONLY,
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+# The DSO is self-contained and exports the sanitizer interface.
+sh_test(
+    name = "asan_shared_dso_test",
+    srcs = ["shared_sanitizer_dso_test.sh"],
+    data = [
+        "@llvm//runtimes/compiler-rt:clang_rt.asan.shared",
+        "@llvm//tools:llvm-nm",
+        "@llvm//tools:llvm-readelf",
+    ],
+    env = {
+        "DSO": "$(rlocationpath @llvm//runtimes/compiler-rt:clang_rt.asan.shared)",
+        "IFACE_PREFIX": "__asan_",
+        "NM": "$(rlocationpath @llvm//tools:llvm-nm)",
+        "READELF": "$(rlocationpath @llvm//tools:llvm-readelf)",
+    },
+    target_compatible_with = _LINUX_ONLY,
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+sh_test(
+    name = "tsan_shared_dso_test",
+    srcs = ["shared_sanitizer_dso_test.sh"],
+    data = [
+        "@llvm//runtimes/compiler-rt:clang_rt.tsan.shared",
+        "@llvm//tools:llvm-nm",
+        "@llvm//tools:llvm-readelf",
+    ],
+    env = {
+        "DSO": "$(rlocationpath @llvm//runtimes/compiler-rt:clang_rt.tsan.shared)",
+        "IFACE_PREFIX": "__tsan_",
+        "NM": "$(rlocationpath @llvm//tools:llvm-nm)",
+        "READELF": "$(rlocationpath @llvm//tools:llvm-readelf)",
+    },
+    target_compatible_with = _LINUX_X86_64_ONLY,
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+# Static build has no sanitizer DSO dep; the shared build does.
+sh_test(
+    name = "asan_shared_link_mode_test",
+    srcs = ["shared_sanitizer_link_mode_test.sh"],
+    data = [
+        ":asan_fail",
+        ":asan_shared_fail",
+        "@llvm//tools:llvm-readelf",
+    ],
+    env = {
+        "READELF": "$(rlocationpath @llvm//tools:llvm-readelf)",
+        "SHARED_BIN": "$(rlocationpath :asan_shared_fail)",
+        "STATIC_BIN": "$(rlocationpath :asan_fail)",
+    },
+    target_compatible_with = _LINUX_ONLY,
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+sh_test(
+    name = "tsan_shared_link_mode_test",
+    srcs = ["shared_sanitizer_link_mode_test.sh"],
+    data = [
+        ":tsan_fail",
+        ":tsan_shared_fail",
+        "@llvm//tools:llvm-readelf",
+    ],
+    env = {
+        "READELF": "$(rlocationpath @llvm//tools:llvm-readelf)",
+        "SHARED_BIN": "$(rlocationpath :tsan_shared_fail)",
+        "STATIC_BIN": "$(rlocationpath :tsan_fail)",
+    },
+    target_compatible_with = _LINUX_X86_64_ONLY,
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
+# Build coverage that the aliases resolve and the DSOs link.
+build_test(
+    name = "shared_sanitizer_targets_build_test",
+    target_compatible_with = _LINUX_ONLY,
+    targets = [
+        "@llvm//runtimes/compiler-rt:clang_rt.asan.shared",
+        "@llvm//runtimes/compiler-rt:clang_rt.asan-preinit.static",
+        "@llvm//runtimes/compiler-rt:clang_rt.tsan.shared",
+    ],
 )
 
 lsan_cc_binary(

--- a/e2e/rules_cc/asan_shared_output_test.sh
+++ b/e2e/rules_cc/asan_shared_output_test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs an asan-instrumented binary linked against the shared (DSO) runtime
+# (--@llvm//config:shared_sanitizer); the DSO is found via LD_LIBRARY_PATH.
+
+# --- begin runfiles.bash initialization v3 ---
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^.*/$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo >&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+EXPECTED_OUTPUT="ERROR: AddressSanitizer: heap-use-after-free on address"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  echo "Skipping ASan runtime check on Darwin; runtime is only provided for Linux."
+  exit 0
+fi
+
+BIN="$(rlocation "${BINARY}")"
+DSO="$(rlocation "${DSO}")"
+
+# Point the loader at the DSO (the binary's DT_NEEDED is its SONAME).
+export LD_LIBRARY_PATH="$(cd "$(dirname "${DSO}")" && pwd):${LD_LIBRARY_PATH:-}"
+
+set +e
+OUTPUT="$("$BIN" 2>&1)"
+set -e
+
+trim() {
+  # shellcheck disable=SC2001
+  echo "$1" | sed 's/[[:space:]]*$//'
+}
+
+if [[ "$(trim "$OUTPUT")" == *"$(trim "$EXPECTED_OUTPUT")"* ]]; then
+  exit 0
+fi
+
+echo "Shared-runtime ASan output does not contain expected string."
+echo "---- Expected ----"
+printf '%s\n' "$EXPECTED_OUTPUT"
+echo "---- Got ----"
+printf '%s\n' "$OUTPUT"
+echo "------------------"
+exit 1

--- a/e2e/rules_cc/defs.bzl
+++ b/e2e/rules_cc/defs.bzl
@@ -89,6 +89,28 @@ asan_cc_binary, _asan_cc_binary_internal = with_cfg(cc_binary).set(
     True,
 ).build()
 
+asan_shared_cc_binary, _asan_shared_cc_binary_internal = with_cfg(cc_binary).set(
+    Label("@llvm//config:asan"),
+    True,
+).set(
+    Label("@llvm//config:host_asan"),
+    True,
+).set(
+    Label("@llvm//config:shared_sanitizer"),
+    True,
+).build()
+
+tsan_shared_cc_binary, _tsan_shared_cc_binary_internal = with_cfg(cc_binary).set(
+    Label("@llvm//config:tsan"),
+    True,
+).set(
+    Label("@llvm//config:host_tsan"),
+    True,
+).set(
+    Label("@llvm//config:shared_sanitizer"),
+    True,
+).build()
+
 lsan_cc_binary, _lsan_cc_binary_internal = with_cfg(cc_binary).set(
     Label("@llvm//config:lsan"),
     True,

--- a/e2e/rules_cc/shared_sanitizer_dso_test.sh
+++ b/e2e/rules_cc/shared_sanitizer_dso_test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks a shared (DSO) compiler-rt sanitizer runtime: it is an ELF shared
+# object, leaves no personality/unwind symbols undefined, does not reference
+# LLVMSupport/zlib/zstd, and exports the sanitizer interface.
+#
+# Env (set by the BUILD target):
+#   DSO          - rlocationpath of the shared runtime (libclang_rt.{asan,tsan}.so)
+#   NM           - rlocationpath of llvm-nm
+#   READELF      - rlocationpath of llvm-readelf
+#   IFACE_PREFIX - exported interface symbol prefix to require (e.g. __asan_)
+
+# --- begin runfiles.bash initialization v3 ---
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^.*/$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo >&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+dso="$(rlocation "${DSO}")"
+nm="$(rlocation "${NM}")"
+readelf="$(rlocation "${READELF}")"
+
+"${readelf}" -h "${dso}" | grep -qE "Type:[[:space:]]+DYN" \
+  || { echo "${dso} is not a shared object (DYN)"; "${readelf}" -h "${dso}"; exit 1; }
+
+undef="${TEST_TMPDIR:-/tmp}/undef.txt"
+"${nm}" -D --undefined-only "${dso}" > "${undef}" 2>/dev/null || true
+
+fail=0
+for sym in __gxx_personality_v0 __gcc_personality_v0 _Unwind_Resume _Unwind_RaiseException; do
+  if grep -qw "${sym}" "${undef}"; then
+    echo "Unexpected undefined symbol (closure should satisfy it): ${sym}"
+    fail=1
+  fi
+done
+
+if grep -qiE "llvm::symbolize|_ZN4llvm|zlibVersion|ZSTD_" "${undef}"; then
+  echo "DSO references LLVMSupport/zlib/zstd (internal symbolizer not dropped):"
+  grep -iE "llvm::symbolize|_ZN4llvm|zlibVersion|ZSTD_" "${undef}" | head
+  fail=1
+fi
+
+# The instrumented app resolves the interface (e.g. __asan_report_*) from the DSO.
+iface_count="$("${nm}" -D --defined-only "${dso}" | grep -cE "[[:xdigit:]]+ [TWtw] ${IFACE_PREFIX}")"
+if [[ "${iface_count}" -lt 10 ]]; then
+  echo "DSO exports too few ${IFACE_PREFIX} interface symbols (${iface_count})"
+  "${nm}" -D --defined-only "${dso}" | grep -iE "asan|tsan|__interceptor|__sanitizer" | head -40
+  fail=1
+fi
+
+if [[ "${fail}" -ne 0 ]]; then
+  echo "---- undefined symbols ----"
+  cat "${undef}"
+  exit 1
+fi

--- a/e2e/rules_cc/shared_sanitizer_link_mode_test.sh
+++ b/e2e/rules_cc/shared_sanitizer_link_mode_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifies --@llvm//config:shared_sanitizer flips the link mode: the static
+# build must not have a sanitizer-runtime DT_NEEDED, the shared build must.
+#
+# Env (set by the BUILD target):
+#   STATIC_BIN - rlocationpath of the binary built with the static sanitizer macro
+#   SHARED_BIN - rlocationpath of the binary built with the shared sanitizer macro
+#   READELF    - rlocationpath of llvm-readelf
+
+# --- begin runfiles.bash initialization v3 ---
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^.*/$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo >&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+static_bin="$(rlocation "${STATIC_BIN}")"
+shared_bin="$(rlocation "${SHARED_BIN}")"
+readelf="$(rlocation "${READELF}")"
+
+# The recorded NEEDED is either libclang_rt.<san>.so or lib<san>.shared.so.
+needed_re='\(NEEDED\).*(clang_rt\.(a|t)san|(a|t)san\.shared|lib(a|t)san)'
+
+static_needed="$("${readelf}" -d "${static_bin}" 2>/dev/null | grep -iE "${needed_re}" || true)"
+shared_needed="$("${readelf}" -d "${shared_bin}" 2>/dev/null | grep -iE "${needed_re}" || true)"
+
+if [[ -n "${static_needed}" ]]; then
+  echo "Static-runtime binary unexpectedly depends on a sanitizer DSO:"
+  printf '%s\n' "${static_needed}"
+  exit 1
+fi
+
+if [[ -z "${shared_needed}" ]]; then
+  echo "Shared-runtime binary is missing the expected sanitizer DSO dependency."
+  "${readelf}" -d "${shared_bin}" || true
+  exit 1
+fi

--- a/e2e/rules_cc/tsan_shared_output_test.sh
+++ b/e2e/rules_cc/tsan_shared_output_test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs a tsan-instrumented binary linked against the shared (DSO) runtime
+# (--@llvm//config:shared_sanitizer); the DSO is found via LD_LIBRARY_PATH.
+
+# --- begin runfiles.bash initialization v3 ---
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^.*/$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo >&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+EXPECTED_OUTPUT="ThreadSanitizer: data race"
+
+BIN="$(rlocation "${BINARY}")"
+DSO="$(rlocation "${DSO}")"
+
+export LD_LIBRARY_PATH="$(cd "$(dirname "${DSO}")" && pwd):${LD_LIBRARY_PATH:-}"
+
+set +e
+OUTPUT="$("$BIN" 2>&1)"
+set -e
+
+if [[ "$OUTPUT" == *"ThreadSanitizer:DEADLYSIGNAL"* && "$OUTPUT" == *"nested bug in the same thread"* ]]; then
+  echo "Skipping TSan runtime check: test environment triggers TSan nested-bug fatal signal."
+  exit 0
+fi
+
+trim() {
+  # shellcheck disable=SC2001
+  echo "$1" | sed 's/[[:space:]]*$//'
+}
+
+if [[ "$(trim "$OUTPUT")" == *"$(trim "$EXPECTED_OUTPUT")"* ]]; then
+  exit 0
+fi
+
+echo "Shared-runtime TSan output does not contain expected string."
+echo "---- Expected ----"
+printf '%s\n' "$EXPECTED_OUTPUT"
+echo "---- Got ----"
+printf '%s\n' "$OUTPUT"
+echo "------------------"
+exit 1

--- a/runtimes/BUILD.bazel
+++ b/runtimes/BUILD.bazel
@@ -246,7 +246,6 @@ copy_to_resource_directory(
             "//runtimes/compiler-rt:clang_rt.asan_cxx.static": "libclang_rt.asan_cxx",
             "//runtimes/compiler-rt:clang_rt.asan_static.static": "libclang_rt.asan_static",
             "//runtimes/compiler-rt:clang_rt.asan.static": "libclang_rt.asan",
-            "//runtimes/compiler-rt:clang_rt.asan.shared": "libclang_rt.asan",
         },
         "//conditions:default": {},
     }) | select({
@@ -256,6 +255,18 @@ copy_to_resource_directory(
         "//config:xray_enabled": {
             "//runtimes/compiler-rt:clang_rt.xray.static": "libclang_rt.xray",
             "//runtimes/compiler-rt:clang_rt.xray_basic.static": "libclang_rt.xray-basic",
+        },
+        "//conditions:default": {},
+    }) | select({
+        # Staged only when shared linking is opted in.
+        "//config:tsan_shared_enabled": {
+            "//runtimes/compiler-rt:clang_rt.tsan.shared": "libclang_rt.tsan",
+        },
+        "//conditions:default": {},
+    }) | select({
+        "//config:asan_shared_enabled": {
+            "//runtimes/compiler-rt:clang_rt.asan.shared": "libclang_rt.asan",
+            "//runtimes/compiler-rt:clang_rt.asan-preinit.static": "libclang_rt.asan-preinit",
         },
         "//conditions:default": {},
     }),

--- a/runtimes/compiler-rt/BUILD.bazel
+++ b/runtimes/compiler-rt/BUILD.bazel
@@ -119,6 +119,12 @@ alias(
 )
 
 alias(
+    name = "clang_rt.tsan.shared",
+    actual = "@llvm-project//compiler-rt:tsan.shared",
+    visibility = ["//visibility:public"],
+)
+
+alias(
     name = "clang_rt.asan.static",
     actual = "@llvm-project//compiler-rt:asan.static",
     visibility = ["//visibility:public"],
@@ -139,6 +145,12 @@ alias(
 alias(
     name = "clang_rt.asan.shared",
     actual = "@llvm-project//compiler-rt:asan.shared",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "clang_rt.asan-preinit.static",
+    actual = "@llvm-project//compiler-rt:asan_preinit.static",
     visibility = ["//visibility:public"],
 )
 

--- a/toolchain/args/BUILD.bazel
+++ b/toolchain/args/BUILD.bazel
@@ -587,6 +587,18 @@ cc_args(
     ],
 )
 
+# Link the shared compiler-rt DSO and add its rpath.
+cc_args(
+    name = "tsan_shared_linker_flags",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = [
+        "-shared-libsan",
+        "-frtlib-add-rpath",
+    ],
+)
+
 cc_args_list(
     name = "tsan_flags",
     args = select({
@@ -597,6 +609,11 @@ cc_args_list(
         "//config:host_tsan_enabled": [
             ":tsan_compiler_flags",
             ":tsan_linker_flags",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//config:tsan_shared_enabled": [
+            ":tsan_shared_linker_flags",
         ],
         "//conditions:default": [],
     }),
@@ -628,6 +645,31 @@ cc_args(
     ],
 )
 
+# -Wno-macro-redefined: the asan runtime redefines _FORTIFY_SOURCE (error under -Werror).
+cc_args(
+    name = "asan_shared_compiler_flags",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-Wno-macro-redefined",
+    ],
+)
+
+# -Wl,--allow-shlib-undefined: don't require data deps to resolve the asan DSO's
+# undefined symbols.
+cc_args(
+    name = "asan_shared_linker_flags",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = [
+        "-shared-libsan",
+        "-frtlib-add-rpath",
+        "-Wl,--allow-shlib-undefined",
+    ],
+)
+
 cc_args_list(
     name = "asan_flags",
     args = select({
@@ -638,6 +680,12 @@ cc_args_list(
         "//config:host_asan_enabled": [
             ":asan_compiler_flags",
             ":asan_linker_flags",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        "//config:asan_shared_enabled": [
+            ":asan_shared_compiler_flags",
+            ":asan_shared_linker_flags",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
Add opt-in support for linking the shared compiler-rt sanitizer runtimes (libclang_rt.asan.so / libclang_rt.tsan.so, suitable for -shared-libsan / LD_PRELOAD), gated behind --@llvm//config:shared_sanitizer. The flag defaults off, so the default static sanitizer linking is unchanged for all consumers.

- config: shared_sanitizer bool_flag + asan_shared_enabled / tsan_shared_enabled config_setting_groups.
- compiler-rt overlay: new tsan PIC shared graph (tsan_pic/tsan_cxx_pic/ tsan_common_runtime/tsan_dynamic/tsan.shared) and asan dynamic-only fork (lsan_common_dynamic/asan_dynamic_runtime/asan_no_internal_symbolizer/ asan_cxx_dynamic/asan_dynamic_shared). The shared DSOs drop the LLVMSupport internal symbolizer (shared-only; static graph untouched) and bake in libcxxabi/libunwind/builtins so __gxx_personality_v0 / _Unwind_* / __gcc_personality_v0 are self-contained.
- asan: compile the shared runtime as the dynamic variant (ASAN_DYNAMIC=1 + -ftls-model=initial-exec); otherwise loading the DSO trips asan's "linked against incompatible ASan runtimes" check.
- runtimes: name each DSO as it is staged/loaded (shared_lib_name = libclang_rt.{asan,tsan}.so) so the SONAME matches the resource-dir filename and the rpath lookup resolves; clang_rt.tsan.shared / clang_rt.asan-preinit.static aliases; shared + preinit resource staging gated on *_shared_enabled.
- libcxxabi: public visibility so the shared runtime closure can whole-archive it.
- toolchain/args: gated -shared-libsan / -frtlib-add-rpath (plus asan -Wno-macro-redefined / -Wl,--allow-shlib-undefined) folded into asan/tsan flags.
- e2e/rules_cc: shared-runtime output tests, DSO self-containment (llvm-nm), link-mode, and build_test coverage.