### PR TITLE
[GPT-5.5] expose sanitizer interface headers only when compiling user programs,

### DIFF
--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -302,9 +302,14 @@ cc_args_list(
             "//toolchain/args:static_link_executable",
         ],
         "//conditions:default": [],
-    }) + [
-        "//toolchain/args/linux:sanitizer_headers_include_search_paths",
-    ],
+    }) + select({
+        # Only expose the sanitizer interface headers when compiling user
+        # programs (runtime_stage=complete), not when building the compiler-rt
+        # runtimes themselves. Those already include compiler-rt/include
+        # directly, and adding it again collides in the sandbox.
+        ":runtimes_all": ["//toolchain/args/linux:sanitizer_headers_include_search_paths"],
+        "//conditions:default": [],
+    }),
 )
 
 # TODO(cerisier): extract those into proper semantic args list.

--- a/toolchain/runtimes/BUILD.bazel
+++ b/toolchain/runtimes/BUILD.bazel
@@ -40,9 +40,13 @@ cc_args_list(
             "//toolchain/args:static_link_executable",
         ],
         "//conditions:default": [],
-    }) + [
-        "//toolchain/args/linux:sanitizer_headers_include_search_paths",
-    ],
+    }) + select({
+        # Runtime builds already include compiler-rt/include directly. Adding
+        # the sanitizer header directory again declares the same tree twice and
+        # makes Bazel's copy-based sandbox fail with "File exists".
+        "//toolchain:runtimes_all": ["//toolchain/args/linux:sanitizer_headers_include_search_paths"],
+        "//conditions:default": [],
+    }),
     visibility = ["//toolchain:__subpackages__"],
 )
 


### PR DESCRIPTION
but not when building the runtimes themselves, as those are already included so adding them again collides in the sandbox