### PR TITLE
compiler-rt/libunwind: build Linux runtimes with CET/BTI marks

### DIFF
--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -493,6 +493,34 @@ cc_library(
     deps = builtins_aarch64_atomic_deps,
 )
 
+# ELF control-flow protection marks (x86_64 IBT+SHSTK, aarch64 BTI+PAC-RET).
+# The builtins and CRT objects link into every consumer binary, and linkers
+# AND-merge GNU property notes: a single unmarked archive member strips the
+# note from the final link, so the marks must originate here.  The added
+# instructions are nops on hardware without the features, and the notes are
+# inert until the kernel/loader enforces them.
+config_setting(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "linux_aarch64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+)
+
+CF_PROTECTION_COPTS = select({
+    ":linux_x86_64": ["-fcf-protection=full"],
+    ":linux_aarch64": ["-mbranch-protection=standard"],
+    "//conditions:default": [],
+})
+
 cc_library(
     name = "builtins",
     srcs = select(
@@ -565,7 +593,7 @@ cc_library(
             "-Wno-pragma-pack",
         ],
         "//conditions:default": [],
-    }),
+    }) + CF_PROTECTION_COPTS,
     implementation_deps = select({
         "@platforms//os:macos": [],
         "@platforms//os:linux": [
@@ -679,7 +707,7 @@ CRT_CFLAGS = [
     "-std=c11",
     "-fPIC",
     "-fno-addrsig",
-]
+] + CF_PROTECTION_COPTS
 
 CRT_DEFINES = [
     "CRT_HAS_INITFINI_ARRAY",

--- a/3rd_party/llvm-project/x.x/libunwind/libunwind.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libunwind/libunwind.BUILD.bazel
@@ -22,6 +22,31 @@ selects.config_setting_group(
     ],
 )
 
+# ELF control-flow protection marks — see the note in
+# compiler-rt/compiler-rt.BUILD.bazel; libunwind is linked (as libgcc_eh/
+# libgcc_s substitute) into every binary the toolchain produces.
+config_setting(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "linux_aarch64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+)
+
+CF_PROTECTION_COPTS = select({
+    ":linux_x86_64": ["-fcf-protection=full"],
+    ":linux_aarch64": ["-mbranch-protection=standard"],
+    "//conditions:default": [],
+})
+
 # The ld64 linker and lld-macho use the libunwind headers only for the constant
 # definitions, in order to parse and convert DWARF to the compact encoding.
 cc_library(
@@ -86,7 +111,7 @@ cc_library(
         "//conditions:default": [],
     }) + [
         "-funwind-tables",
-    ],
+    ] + CF_PROTECTION_COPTS,
     cxxopts = [
         "-fno-exceptions",
         "-fno-rtti",


### PR DESCRIPTION
## Motivation

ELF linkers AND-merge `.note.gnu.property` across all inputs: if a single object lacks the note, the IBT/SHSTK (x86_64) or BTI/PAC-RET (aarch64) marks are stripped from the final binary. Because the compiler-rt builtins, the CRT begin/end objects, and libunwind link into essentially every binary this toolchain produces, they currently make it impossible for any downstream to ship control-flow-protected binaries — even when all consumer code compiles with `-fcf-protection` / `-mbranch-protection`, the runtimes drop the note at link time.

## Change

Build the builtins, CRT objects, and libunwind with `-fcf-protection=full` (linux x86_64) and `-mbranch-protection=standard` (linux aarch64), via two `config_setting`s and a shared `CF_PROTECTION_COPTS` select in each BUILD file. Other OSes and architectures are unaffected (`//conditions:default: []`).

This matches what major distros ship for libgcc/compiler-rt (Fedora, Debian, SUSE build them CET-marked), and is safe by construction:

- the added `endbr64` / `bti c` / `paciasp` instructions are architectural nops on hardware without the features;
- the property notes are inert metadata until a kernel/loader opts into enforcement;
- compiler-rt's aarch64 builtins asm (`lib/builtins/assembly.h`) and libunwind's register save/restore asm already emit the note themselves when the feature macros are defined, so passing the flag to the `.S` compiles is sufficient — no asm changes needed.

## Validation

- the builtins archive members gain `.note.gnu.property` sections and `endbr64` instructions;
- a glibc built with `--enable-cet` and linked against these runtimes now carries `GNU_PROPERTY` on `libc.so.6` and `ld-linux-x86-64.so.2` (previously stripped);

## Possible follow-up

libc++/libc++abi would want the same treatment for C++ consumers; left out here to keep the change focused on the objects that reach every link.