### PR TITLE
Rename soname feature to set_soname

### DIFF
--- a/toolchain/features/legacy/BUILD.bazel
+++ b/toolchain/features/legacy/BUILD.bazel
@@ -123,7 +123,8 @@ cc_feature_set(
         "@rules_cc//cc/toolchains/args/strip_flags:feature",
         "@rules_cc//cc/toolchains/args/objc_arc_flags:feature",
         # Inlined below as it isn't visible and also has an issue upstream.
-        ":soname_flags",
+        # TODO: Use upstream version after https://github.com/bazelbuild/rules_cc/pull/797
+        ":set_soname",
         # Intentionally omitted since we link runtime libraries ourselves and
         # including this flag just raises a warning.
         # "@rules_cc//cc/toolchains/args/static_libgcc:feature",
@@ -148,27 +149,19 @@ cc_feature_set(
 # Taken from (with fixes)
 # https://github.com/bazelbuild/rules_cc/blob/541eda5d72e9b5f18e6a24e8d14975afcd865717/cc/toolchains/args/soname_flags/BUILD#L4-L31
 cc_feature(
-    name = "soname_flags",
+    name = "set_soname",
+    args = [":set_soname_args"],
+    feature_name = "set_soname",  # Feature name is important and read by rules_cc
+)
+
+cc_args(
+    name = "set_soname_args",
+    actions = ["@rules_cc//cc/toolchains/actions:dynamic_library_link_actions"],
     args = select({
-        "@platforms//os:macos": [":macos_set_install_name"],
-        "@platforms//os:linux": [":set_soname"],
+        "@rules_cc//cc/settings:apple_constraint": ["-Wl,-install_name,@rpath/{runtime_solib_name}"],
+        "@platforms//os:linux": ["-Wl,-soname,{runtime_solib_name}"],
         "//conditions:default": [],
     }),
-    feature_name = "_soname_flags",  # Doesn't override legacy feature, but shouldn't be disabled
-)
-
-cc_args(
-    name = "macos_set_install_name",
-    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = ["-Wl,-install_name,@rpath/{runtime_solib_name}"],
-    format = {"runtime_solib_name": "@rules_cc//cc/toolchains/variables:runtime_solib_name"},
-    requires_not_none = "@rules_cc//cc/toolchains/variables:runtime_solib_name",
-)
-
-cc_args(
-    name = "set_soname",
-    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = ["-Wl,-soname,{runtime_solib_name}"],
     format = {"runtime_solib_name": "@rules_cc//cc/toolchains/variables:runtime_solib_name"},
     requires_not_none = "@rules_cc//cc/toolchains/variables:runtime_solib_name",
 )


### PR DESCRIPTION
This feature name is now meaningful https://github.com/bazelbuild/rules_cc/commit/f2cb3b4d2076de7ecdcfeac9c97e29d138783183

We can't use the upstream version because it doesn't default to enabled
for Linux today.
