### PR TITLE
Support producing interface libraries

### DIFF
--- a/tests/interface_libraries/BUILD.bazel
+++ b/tests/interface_libraries/BUILD.bazel
@@ -1,0 +1,24 @@
+load(":interface_library_test.bzl", "interface_library_test", "test_shared_library")
+
+test_shared_library(
+    name = "unversioned",
+    srcs = ["unversioned.c"],
+)
+
+test_shared_library(
+    name = "versioned",
+    srcs = ["versioned.c"],
+    additional_linker_inputs = ["versioned.lds"],
+    linkopts = ["-Wl,--version-script,$(execpath versioned.lds)"],
+)
+
+interface_library_test(
+    name = "unversioned_test",
+    library = ":unversioned",
+)
+
+interface_library_test(
+    name = "versioned_test",
+    library = ":versioned",
+    versioned_symbols = True,
+)

--- a/tests/interface_libraries/interface_library_test.bzl
+++ b/tests/interface_libraries/interface_library_test.bzl
@@ -1,0 +1,115 @@
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+
+def _test_shared_library_impl(ctx):
+    cc_toolchain = find_cpp_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+    compilation_context, compilation_outputs = cc_common.compile(
+        actions = ctx.actions,
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+        name = ctx.label.name,
+        srcs = ctx.files.srcs,
+    )
+    linking_context, linking_outputs = cc_common.create_linking_context_from_compilation_outputs(
+        actions = ctx.actions,
+        additional_inputs = ctx.files.additional_linker_inputs,
+        cc_toolchain = cc_toolchain,
+        compilation_outputs = compilation_outputs,
+        disallow_static_libraries = True,
+        feature_configuration = feature_configuration,
+        name = ctx.label.name,
+        user_link_flags = [
+            ctx.expand_location(linkopt, targets = ctx.attr.additional_linker_inputs)
+            for linkopt in ctx.attr.linkopts
+        ],
+    )
+
+    library = linking_outputs.library_to_link
+    files = [library.dynamic_library]
+    if library.interface_library != None:
+        files.append(library.interface_library)
+
+    return [
+        DefaultInfo(files = depset(files)),
+        CcInfo(
+            compilation_context = compilation_context,
+            linking_context = linking_context,
+        ),
+    ]
+
+test_shared_library = rule(
+    implementation = _test_shared_library_impl,
+    attrs = {
+        "additional_linker_inputs": attr.label_list(allow_files = True),
+        "linkopts": attr.string_list(),
+        "srcs": attr.label_list(allow_files = [".c", ".cc"]),
+    },
+    fragments = ["cpp"],
+    provides = [CcInfo],
+    toolchains = use_cpp_toolchain(),
+)
+
+def _interface_library_test_impl(ctx):
+    libraries = []
+    for linker_input in ctx.attr.library[CcInfo].linking_context.linker_inputs.to_list():
+        libraries.extend(linker_input.libraries)
+
+    if len(libraries) != 1:
+        fail("{} must propagate exactly one library through CcInfo, got {}".format(
+            ctx.attr.library.label,
+            len(libraries),
+        ))
+
+    library = libraries[0]
+    if library.dynamic_library == None:
+        fail("{} does not propagate a dynamic_library through CcInfo".format(ctx.attr.library.label))
+    if library.interface_library == None:
+        fail("{} does not propagate an interface_library through CcInfo".format(ctx.attr.library.label))
+
+    executable = ctx.actions.declare_file(ctx.label.name + ".sh")
+    ctx.actions.expand_template(
+        is_executable = True,
+        output = executable,
+        substitutions = {},
+        template = ctx.file._test_script,
+    )
+
+    dynamic_library = library.dynamic_library
+    interface_library = library.interface_library
+    return [
+        DefaultInfo(
+            executable = executable,
+            runfiles = ctx.runfiles(files = [
+                dynamic_library,
+                interface_library,
+            ]),
+        ),
+        RunEnvironmentInfo(environment = {
+            "DYNAMIC_LIBRARY": dynamic_library.short_path,
+            "INTERFACE_LIBRARY": interface_library.short_path,
+            "VERSIONED_SYMBOLS": "yes" if ctx.attr.versioned_symbols else "no",
+        }),
+    ]
+
+interface_library_test = rule(
+    implementation = _interface_library_test_impl,
+    attrs = {
+        "library": attr.label(
+            mandatory = True,
+            providers = [CcInfo],
+        ),
+        "versioned_symbols": attr.bool(),
+        "_test_script": attr.label(
+            allow_single_file = True,
+            default = ":verify_interface_library.sh",
+        ),
+    },
+    test = True,
+)

--- a/tests/interface_libraries/unversioned.c
+++ b/tests/interface_libraries/unversioned.c
@@ -1,0 +1,3 @@
+int unversioned(void) {
+    return 42;
+}

--- a/tests/interface_libraries/verify_interface_library.sh
+++ b/tests/interface_libraries/verify_interface_library.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$VERSIONED_SYMBOLS" == "yes" ]]; then
+  if ! cmp -s "$DYNAMIC_LIBRARY" "$INTERFACE_LIBRARY"; then
+    echo "error: interface library for versioned symbols is not a copy of the dynamic library" >&2
+    exit 1
+  fi
+elif cmp -s "$DYNAMIC_LIBRARY" "$INTERFACE_LIBRARY"; then
+  echo "error: interface library for unversioned symbols is a copy of the dynamic library" >&2
+  exit 1
+fi

--- a/tests/interface_libraries/versioned.c
+++ b/tests/interface_libraries/versioned.c
@@ -1,0 +1,3 @@
+int versioned(void) {
+    return 42;
+}

--- a/tests/interface_libraries/versioned.lds
+++ b/tests/interface_libraries/versioned.lds
@@ -1,0 +1,6 @@
+VERSION_1 {
+    global:
+        versioned;
+    local:
+        *;
+};

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -90,6 +90,17 @@ config_setting(
 )
 
 config_setting(
+    name = "linux_complete",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+    flag_values = {
+        ":runtime_stage": "complete",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "macos_complete",
     constraint_values = [
         "@platforms//os:macos",
@@ -389,6 +400,14 @@ cc_artifact_name_pattern(
     name = "macos_dynamic_library_pattern",
     category = "@rules_cc//cc/toolchains/artifacts:dynamic_library",
     extension = ".dylib",
+    prefix = "lib",
+    visibility = ["//visibility:public"],
+)
+
+cc_artifact_name_pattern(
+    name = "macos_interface_library_pattern",
+    category = "@rules_cc//cc/toolchains/artifacts:interface_library",
+    extension = ".tbd",
     prefix = "lib",
     visibility = ["//visibility:public"],
 )

--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -56,7 +56,7 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
         "visibility": ["//visibility:public"],
     }
 
-    BASE_TOOLS = {
+    TOOLS_WITHOUT_LINKER = {
         "@rules_cc//cc/toolchains/actions:assembly_actions": prefix + "/clang",
         "@rules_cc//cc/toolchains/actions:c_compile": prefix + "/clang",
         "@rules_cc//cc/toolchains/actions:gcov": prefix + "/gcov",
@@ -65,9 +65,11 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
         "@rules_cc//cc/toolchains/actions:objc_compile": prefix + "/clang",
         "@llvm//toolchain:cpp_compile_actions_without_header_parsing": prefix + "/clang++",
         "@rules_cc//cc/toolchains/actions:dwp": prefix + "/llvm-dwp",
-        "@rules_cc//cc/toolchains/actions:link_actions": prefix + "/lld",
         "@rules_cc//cc/toolchains/actions:objcopy_embed_data": prefix + "/llvm-objcopy",
         "@rules_cc//cc/toolchains/actions:strip": prefix + "/llvm-strip",
+    }
+    BASE_TOOLS = TOOLS_WITHOUT_LINKER | {
+        "@rules_cc//cc/toolchains/actions:link_actions": prefix + "/lld",
     }
 
     COMPLETE_ONLY_TOOLS = {
@@ -83,8 +85,9 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
 
     cc_tool_map(
         name = prefix + "/tools_with_interface_libraries",
-        tools = BASE_TOOLS | COMPLETE_ONLY_TOOLS | {
-            "@rules_cc//cc/toolchains/actions:link_actions": prefix + "/link-wrapper",
+        tools = TOOLS_WITHOUT_LINKER | COMPLETE_ONLY_TOOLS | {
+            "@rules_cc//cc/toolchains/actions:link_executable_actions": prefix + "/lld",
+            "@rules_cc//cc/toolchains/actions:dynamic_library_link_actions": prefix + "/link-wrapper",
             "@rules_cc//cc/toolchains/actions:ar_actions": prefix + "/llvm-ar",
         },
     )

--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -279,15 +279,16 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
         ],
     )
 
+    # Preserve the `-clang++` suffix for rustc's linker-flavor inference.
     bootstrap_binary(
-        name = prefix + "/bin/link-wrapper",
+        name = prefix + "/bin/link-wrapper-clang++",
         actual = "@llvm//tools/internal:link-wrapper",
         **bootstrap_binary_kwargs
     )
 
     cc_tool(
         name = prefix + "/link-wrapper",
-        src = prefix + "/bin/link-wrapper",
+        src = prefix + "/bin/link-wrapper-clang++",
         data = [
             prefix + "/bin/clang++",
             prefix + "/bin/dsymutil",

--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -82,6 +82,14 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
     )
 
     cc_tool_map(
+        name = prefix + "/tools_with_interface_libraries",
+        tools = BASE_TOOLS | COMPLETE_ONLY_TOOLS | {
+            "@rules_cc//cc/toolchains/actions:link_actions": prefix + "/link-wrapper",
+            "@rules_cc//cc/toolchains/actions:ar_actions": prefix + "/llvm-ar",
+        },
+    )
+
+    cc_tool_map(
         name = prefix + "/tools_with_libtool",
         tools = BASE_TOOLS | COMPLETE_ONLY_TOOLS | {
             "@rules_cc//cc/toolchains/actions:ar_actions": prefix + "/llvm-libtool-darwin",
@@ -187,11 +195,16 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
         },
     )
 
-    bootstrap_binary(
-        name = prefix + "/bin/llvm-nm",
-        actual = "@llvm-project//llvm:llvm.stripped",
-        **bootstrap_binary_kwargs
-    )
+    for tool in [
+        "llvm-ifs",
+        "llvm-nm",
+        "llvm-readtapi",
+    ]:
+        bootstrap_binary(
+            name = prefix + "/bin/" + tool,
+            actual = "@llvm-project//llvm:llvm.stripped",
+            **bootstrap_binary_kwargs
+        )
 
     bootstrap_binary(
         name = prefix + "/bin/c++filt",
@@ -279,16 +292,29 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
             prefix + "/bin/ld.lld",
             prefix + "/bin/ld64.lld",
             prefix + "/bin/lld",
+            prefix + "/bin/llvm-ifs",
+            prefix + "/bin/llvm-nm",
+            prefix + "/bin/llvm-readtapi",
             prefix + "/bin/wasm-ld",
+        ],
+        capabilities = [
+            "@rules_cc//cc/toolchains/capabilities:has_configured_linker_path",
+            "@rules_cc//cc/toolchains/capabilities:supports_interface_shared_libraries",
         ],
         env = {
             "LLVM_CLANGXX": "{clangxx}",
             "LLVM_DSYMUTIL": "{dsymutil}",
+            "LLVM_IFS": "{llvm_ifs}",
+            "LLVM_NM": "{llvm_nm}",
+            "LLVM_READTAPI": "{llvm_readtapi}",
             "LLVM_STRIP": "{strip}",
         },
         format = {
             "clangxx": prefix + "/bin/clang++",
             "dsymutil": prefix + "/bin/dsymutil",
+            "llvm_ifs": prefix + "/bin/llvm-ifs",
+            "llvm_nm": prefix + "/bin/llvm-nm",
+            "llvm_readtapi": prefix + "/bin/llvm-readtapi",
             "strip": prefix + "/bin/llvm-strip",
         },
     )
@@ -383,6 +409,7 @@ def declare_toolchains(*, execs = None, targets = SUPPORTED_TARGETS):
             cc_toolchain(
                 name = cc_toolchain_name,
                 tool_map = select({
+                    "@llvm//toolchain:linux_complete": ":%s/tools_with_interface_libraries" % tool_prefix,
                     "@llvm//toolchain:macos_complete_with_libtool": ":%s/tools_with_dsym_and_libtool" % tool_prefix,
                     "@llvm//toolchain:macos_complete": ":%s/tools_with_dsym" % tool_prefix,
                     "@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_apple_setting": ":%s/tools_with_libtool_for_runtime" % tool_prefix,

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -19,6 +19,14 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             # "@rules_cc//cc/toolchains/args/thin_lto:feature",
             "@llvm//toolchain/features/thin_lto:feature",
         ] + select({
+            "@platforms//os:linux": [
+                "@llvm//toolchain/features/interface_libraries:feature",
+            ],
+            "@platforms//os:macos": [
+                "@llvm//toolchain/features/interface_libraries:feature",
+            ],
+            "//conditions:default": [],
+        }) + select({
             "@llvm//toolchain:macos_complete": [
                 "@llvm//toolchain/features:generate_dsym_file",
             ],
@@ -37,10 +45,12 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
         name = name + "_enabled_features",
         all_of = select({
             "@platforms//os:linux": [
+                "@llvm//toolchain/features/interface_libraries:feature",
                 "@llvm//toolchain/features:static_link_cpp_runtimes",
                 "@llvm//toolchain/features/runtime_library_search_directories:feature",
             ],
             "@platforms//os:macos": [
+                "@llvm//toolchain/features/interface_libraries:feature",
                 # macOS links libc++ from the SDK, so it doesn't statically link
                 # the C++ runtimes. But it does need dynamic runtime libs (e.g.
                 # sanitizer dylibs) placed in runfiles with an @loader_path rpath,
@@ -101,6 +111,7 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
         artifact_name_patterns = select({
             "@platforms//os:macos": [
                 "@llvm//toolchain:macos_dynamic_library_pattern",
+                "@llvm//toolchain:macos_interface_library_pattern",
             ],
             "@platforms//os:windows": [
                 "@llvm//toolchain:windows_executable_pattern",

--- a/toolchain/features/interface_libraries/BUILD.bazel
+++ b/toolchain/features/interface_libraries/BUILD.bazel
@@ -1,0 +1,60 @@
+load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
+load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
+
+cc_feature_set(
+    name = "feature",
+    all_of = [
+        ":build_interface_libraries",
+        ":dynamic_library_linker_tool",
+    ],
+    visibility = ["//toolchain:__pkg__"],
+)
+
+cc_feature(
+    name = "dynamic_library_linker_tool",
+    overrides = "@rules_cc//cc/toolchains/features/legacy:dynamic_library_linker_tool",
+)
+
+cc_feature(
+    name = "build_interface_libraries",
+    args = [
+        ":generate_interface_library",
+        ":interface_library_input",
+        ":interface_library_output",
+    ],
+    overrides = "@rules_cc//cc/toolchains/features/legacy:build_interface_libraries",
+)
+
+cc_args(
+    name = "generate_interface_library",
+    actions = ["@rules_cc//cc/toolchains/actions:dynamic_library_link_actions"],
+    env = {
+        "LLVM_GENERATE_INTERFACE_LIBRARY": "{generate_interface_library}",
+    } | select({
+        "@platforms//os:linux": {"LLVM_INTERFACE_LIBRARY_FORMAT": "elf"},
+        "@platforms//os:macos": {"LLVM_INTERFACE_LIBRARY_FORMAT": "tbd"},
+        "//conditions:default": {},
+    }),
+    format = {"generate_interface_library": "@rules_cc//cc/toolchains/variables:generate_interface_library"},
+    requires_any_of = ["@rules_cc//cc/toolchains/capabilities:supports_interface_shared_libraries"],
+    requires_not_none = "@rules_cc//cc/toolchains/variables:generate_interface_library",
+)
+
+cc_args(
+    name = "interface_library_input",
+    actions = ["@rules_cc//cc/toolchains/actions:dynamic_library_link_actions"],
+    env = {"LLVM_INTERFACE_LIBRARY_INPUT": "{interface_library_input_path}"},
+    format = {"interface_library_input_path": "@rules_cc//cc/toolchains/variables:interface_library_input_path"},
+    requires_any_of = ["@rules_cc//cc/toolchains/capabilities:supports_interface_shared_libraries"],
+    requires_not_none = "@rules_cc//cc/toolchains/variables:interface_library_input_path",
+)
+
+cc_args(
+    name = "interface_library_output",
+    actions = ["@rules_cc//cc/toolchains/actions:dynamic_library_link_actions"],
+    env = {"LLVM_INTERFACE_LIBRARY_OUTPUT": "{interface_library_output_path}"},
+    format = {"interface_library_output_path": "@rules_cc//cc/toolchains/variables:interface_library_output_path"},
+    requires_any_of = ["@rules_cc//cc/toolchains/capabilities:supports_interface_shared_libraries"],
+    requires_not_none = "@rules_cc//cc/toolchains/variables:interface_library_output_path",
+)

--- a/toolchain/features/interface_libraries/BUILD.bazel
+++ b/toolchain/features/interface_libraries/BUILD.bazel
@@ -8,7 +8,7 @@ cc_feature_set(
         ":build_interface_libraries",
         ":dynamic_library_linker_tool",
     ],
-    visibility = ["//toolchain:__pkg__"],
+    visibility = ["//visibility:public"],
 )
 
 cc_feature(

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -121,6 +121,15 @@ def declare_llvm_targets(*, suffix = ""):
     )
 
     cc_tool_map(
+        name = "tools_with_interface_libraries",
+        tools = BASE_TOOLS | COMPLETE_ONLY_TOOLS | {
+            "@rules_cc//cc/toolchains/actions:link_actions": ":link-wrapper",
+            "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-ar",
+        },
+        visibility = ["//visibility:public"],
+    )
+
+    cc_tool_map(
         name = "staged_default_tools",
         tools = BASE_TOOLS | {
             "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-ar",
@@ -221,16 +230,29 @@ def declare_llvm_targets(*, suffix = ""):
             "bin/ld.lld" + suffix,
             "bin/ld64.lld" + suffix,
             "bin/lld" + suffix,
+            "bin/llvm-ifs" + suffix,
+            "bin/llvm-nm" + suffix,
+            "bin/llvm-readtapi" + suffix,
             "bin/wasm-ld" + suffix,
+        ],
+        capabilities = [
+            "@rules_cc//cc/toolchains/capabilities:has_configured_linker_path",
+            "@rules_cc//cc/toolchains/capabilities:supports_interface_shared_libraries",
         ],
         env = {
             "LLVM_CLANGXX": "{clangxx}",
             "LLVM_DSYMUTIL": "{dsymutil}",
+            "LLVM_IFS": "{llvm_ifs}",
+            "LLVM_NM": "{llvm_nm}",
+            "LLVM_READTAPI": "{llvm_readtapi}",
             "LLVM_STRIP": "{strip}",
         },
         format = {
             "clangxx": ":clangxx_file",
             "dsymutil": ":dsymutil_file",
+            "llvm_ifs": "bin/llvm-ifs" + suffix,
+            "llvm_nm": "bin/llvm-nm" + suffix,
+            "llvm_readtapi": "bin/llvm-readtapi" + suffix,
             "strip": ":strip_file",
         },
     )

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -94,7 +94,7 @@ def declare_llvm_targets(*, suffix = ""):
         },
     )
 
-    BASE_TOOLS = {
+    TOOLS_WITHOUT_LINKER = {
         "@rules_cc//cc/toolchains/actions:assembly_actions": ":clang",
         "@rules_cc//cc/toolchains/actions:c_compile": ":clang",
         "@rules_cc//cc/toolchains/actions:gcov": ":gcov",
@@ -102,10 +102,12 @@ def declare_llvm_targets(*, suffix = ""):
         "@rules_cc//cc/toolchains/actions:llvm_profdata": ":llvm-profdata",
         "@rules_cc//cc/toolchains/actions:objc_compile": ":clang",
         "@llvm//toolchain:cpp_compile_actions_without_header_parsing": ":clang++",
-        "@rules_cc//cc/toolchains/actions:link_actions": ":lld",
         "@rules_cc//cc/toolchains/actions:objcopy_embed_data": ":llvm-objcopy",
         "@rules_cc//cc/toolchains/actions:dwp": ":llvm-dwp",
         "@rules_cc//cc/toolchains/actions:strip": ":llvm-strip",
+    }
+    BASE_TOOLS = TOOLS_WITHOUT_LINKER | {
+        "@rules_cc//cc/toolchains/actions:link_actions": ":lld",
     }
 
     COMPLETE_ONLY_TOOLS = {
@@ -122,8 +124,9 @@ def declare_llvm_targets(*, suffix = ""):
 
     cc_tool_map(
         name = "tools_with_interface_libraries",
-        tools = BASE_TOOLS | COMPLETE_ONLY_TOOLS | {
-            "@rules_cc//cc/toolchains/actions:link_actions": ":link-wrapper",
+        tools = TOOLS_WITHOUT_LINKER | COMPLETE_ONLY_TOOLS | {
+            "@rules_cc//cc/toolchains/actions:link_executable_actions": ":lld",
+            "@rules_cc//cc/toolchains/actions:dynamic_library_link_actions": ":link-wrapper",
             "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm-ar",
         },
         visibility = ["//visibility:public"],

--- a/toolchain/selects.bzl
+++ b/toolchain/selects.bzl
@@ -53,6 +53,7 @@ def platform_cc_tool_map(exec_os, exec_cpu):
     # point at further aliases that use `select`, those will resolve according to the exec platform.
     # See https://github.com/bazelbuild/bazel/issues/27623#issuecomment-3529439585 for more details.
     return select({
+        "@llvm//toolchain:linux_complete": Label(tool_repo + ":tools_with_interface_libraries"),
         "@llvm//toolchain:macos_complete_with_libtool": Label(tool_repo + ":tools_with_dsym_and_libtool"),
         "@llvm//toolchain:macos_complete": Label(tool_repo + ":tools_with_dsym"),
         "@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_apple_setting": Label(tool_repo + ":tools_with_libtool_for_runtime"),

--- a/tools/internal/BUILD.bazel
+++ b/tools/internal/BUILD.bazel
@@ -12,9 +12,17 @@ cc_runtime_stage1_hosted_binary(
     visibility = ["//visibility:public"],
 )
 
+# rustc infers the linker flavor from the executable name. Keep the `-clang++`
+# suffix so Rust shared-library links treat this wrapper as a compiler driver.
 cc_runtime_stage1_hosted_binary(
-    name = "link-wrapper",
+    name = "link-wrapper-clang++",
     srcs = ["link_wrapper.c"],
     features = ["-generate_dsym_file"],
+    visibility = ["//tools/internal:__pkg__"],
+)
+
+alias(
+    name = "link-wrapper",
+    actual = ":link-wrapper-clang++",
     visibility = ["//visibility:public"],
 )

--- a/tools/internal/link_wrapper.c
+++ b/tools/internal/link_wrapper.c
@@ -1,9 +1,15 @@
+#ifndef _WIN32
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #ifdef _WIN32
+#include <io.h>
 #include <process.h>
 #else
 #include <sys/types.h>
@@ -54,6 +60,69 @@ static int run_process(char *const args[]) {
 #endif
 }
 
+static int run_process_with_stdout(char *const args[], FILE *output) {
+#ifdef _WIN32
+    int stdout_fd = _fileno(stdout);
+    int saved_stdout = _dup(stdout_fd);
+    if (saved_stdout == -1) {
+        fprintf(stderr, "link-wrapper: failed to duplicate stdout for %s: %s\n", args[0], strerror(errno));
+        return 127;
+    }
+
+    fflush(stdout);
+    if (_dup2(_fileno(output), stdout_fd) == -1) {
+        fprintf(stderr, "link-wrapper: failed to redirect stdout for %s: %s\n", args[0], strerror(errno));
+        _close(saved_stdout);
+        return 127;
+    }
+
+    int status = run_process(args);
+    fflush(stdout);
+    if (_dup2(saved_stdout, stdout_fd) == -1) {
+        fprintf(stderr, "link-wrapper: failed to restore stdout after %s: %s\n", args[0], strerror(errno));
+        status = 127;
+    }
+    _close(saved_stdout);
+    return status;
+#else
+    pid_t pid = fork();
+    if (pid == -1) {
+        fprintf(stderr, "link-wrapper: failed to fork for %s: %s\n", args[0], strerror(errno));
+        return 127;
+    }
+
+    if (pid == 0) {
+        if (dup2(fileno(output), STDOUT_FILENO) == -1) {
+            fprintf(stderr, "link-wrapper: failed to redirect stdout for %s: %s\n", args[0], strerror(errno));
+            _exit(127);
+        }
+        execv(args[0], args);
+        fprintf(stderr, "link-wrapper: failed to execute %s: %s\n", args[0], strerror(errno));
+        _exit(127);
+    }
+
+    int status = 0;
+    while (1) {
+        if (waitpid(pid, &status, 0) != -1) {
+            break;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        fprintf(stderr, "link-wrapper: failed to wait for %s: %s\n", args[0], strerror(errno));
+        return 127;
+    }
+
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+        return 128 + WTERMSIG(status);
+    }
+    return 127;
+#endif
+}
+
 static const char *required_env(const char *name) {
     const char *value = getenv(name);
     if (value == NULL || value[0] == '\0') {
@@ -63,7 +132,136 @@ static const char *required_env(const char *name) {
     return value;
 }
 
+static int copy_file(const char *source_path, const char *destination_path) {
+    FILE *source = fopen(source_path, "rb");
+    if (source == NULL) {
+        fprintf(stderr, "link-wrapper: failed to open %s: %s\n", source_path, strerror(errno));
+        return 1;
+    }
+
+    FILE *destination = fopen(destination_path, "wb");
+    if (destination == NULL) {
+        fprintf(stderr, "link-wrapper: failed to open %s: %s\n", destination_path, strerror(errno));
+        fclose(source);
+        return 1;
+    }
+
+    char buffer[64 * 1024];
+    int status = 0;
+    while (!feof(source)) {
+        size_t bytes_read = fread(buffer, 1, sizeof(buffer), source);
+        if (bytes_read > 0 && fwrite(buffer, 1, bytes_read, destination) != bytes_read) {
+            fprintf(stderr, "link-wrapper: failed to write %s: %s\n", destination_path, strerror(errno));
+            status = 1;
+            break;
+        }
+        if (ferror(source)) {
+            fprintf(stderr, "link-wrapper: failed to read %s\n", source_path);
+            status = 1;
+            break;
+        }
+    }
+
+    if (fclose(destination) != 0 && status == 0) {
+        fprintf(stderr, "link-wrapper: failed to close %s: %s\n", destination_path, strerror(errno));
+        status = 1;
+    }
+    if (fclose(source) != 0 && status == 0) {
+        fprintf(stderr, "link-wrapper: failed to close %s: %s\n", source_path, strerror(errno));
+        status = 1;
+    }
+    if (status != 0) {
+        remove(destination_path);
+    }
+    return status;
+}
+
+static int has_versioned_symbols(const char *library_path, bool *result) {
+    const char *llvm_nm = required_env("LLVM_NM");
+    char *nm_args[] = {
+        (char *)llvm_nm,
+        "--dynamic",
+        "--defined-only",
+        "--format=just-symbols",
+        (char *)library_path,
+        NULL,
+    };
+
+    FILE *output = tmpfile();
+    if (output == NULL) {
+        fprintf(stderr, "link-wrapper: failed to create temporary llvm-nm output: %s\n", strerror(errno));
+        return 1;
+    }
+
+    int status = run_process_with_stdout(nm_args, output);
+    if (status != 0) {
+        fclose(output);
+        return status;
+    }
+
+    if (fseek(output, 0, SEEK_SET) != 0) {
+        fprintf(stderr, "link-wrapper: failed to rewind llvm-nm output: %s\n", strerror(errno));
+        fclose(output);
+        return 1;
+    }
+    *result = false;
+    char buffer[4096];
+    while (fgets(buffer, sizeof(buffer), output) != NULL) {
+        if (strchr(buffer, '@') != NULL) {
+            *result = true;
+            break;
+        }
+    }
+    if (ferror(output)) {
+        fprintf(stderr, "link-wrapper: failed to read llvm-nm output\n");
+        status = 1;
+    }
+    fclose(output);
+    return status;
+}
+
+static int generate_interface_library(const char *format, const char *input_path, const char *output_path) {
+    if (strcmp(format, "elf") == 0) {
+        bool has_versions = false;
+        int status = has_versioned_symbols(input_path, &has_versions);
+        if (status != 0) {
+            return status;
+        }
+        if (has_versions) {
+            return copy_file(input_path, output_path);
+        }
+
+        const char *llvm_ifs = required_env("LLVM_IFS");
+        char *ifs_args[] = {
+            (char *)llvm_ifs,
+            (char *)input_path,
+            "--output-elf",
+            (char *)output_path,
+            NULL,
+        };
+        return run_process(ifs_args);
+    }
+
+    if (strcmp(format, "tbd") == 0) {
+        const char *llvm_readtapi = required_env("LLVM_READTAPI");
+        char *readtapi_args[] = {
+            (char *)llvm_readtapi,
+            "-stubify",
+            (char *)input_path,
+            "-o",
+            (char *)output_path,
+            NULL,
+        };
+        return run_process(readtapi_args);
+    }
+
+    fprintf(stderr, "link-wrapper: unsupported interface library format: %s\n", format);
+    return 1;
+}
+
 int main(int argc, char **argv) {
+    (void)argc;
+
     const char *clangxx = required_env("LLVM_CLANGXX");
     const char *strip_debug_symbols = getenv("LLVM_STRIP_DEBUG_SYMBOLS");
     int should_strip_debug_symbols = strip_debug_symbols != NULL && strip_debug_symbols[0] != '\0';
@@ -75,33 +273,46 @@ int main(int argc, char **argv) {
     }
 
     const char *dsym_path = getenv("LLVM_DSYM_PATH");
-    if (dsym_path == NULL || dsym_path[0] == '\0') {
+    if (dsym_path != NULL && dsym_path[0] != '\0') {
+        const char *link_output = required_env("LLVM_LINK_OUTPUT");
+        const char *dsymutil = required_env("LLVM_DSYMUTIL");
+
+        char *dsym_args[] = {
+            (char *)dsymutil,
+            "-o",
+            (char *)dsym_path,
+            (char *)link_output,
+            NULL,
+        };
+
+        status = run_process(dsym_args);
+        if (status != 0) {
+            return status;
+        }
+
+        if (should_strip_debug_symbols) {
+            const char *strip = required_env("LLVM_STRIP");
+            char *strip_args[] = {
+                (char *)strip,
+                "-S",
+                (char *)link_output,
+                NULL,
+            };
+
+            status = run_process(strip_args);
+            if (status != 0) {
+                return status;
+            }
+        }
+    }
+
+    const char *generate_interface = getenv("LLVM_GENERATE_INTERFACE_LIBRARY");
+    if (generate_interface == NULL || strcmp(generate_interface, "yes") != 0) {
         return 0;
     }
 
-    const char *link_output = required_env("LLVM_LINK_OUTPUT");
-    const char *dsymutil = required_env("LLVM_DSYMUTIL");
-
-    char *dsym_args[] = {
-        (char *)dsymutil,
-        "-o",
-        (char *)dsym_path,
-        (char *)link_output,
-        NULL,
-    };
-
-    status = run_process(dsym_args);
-    if (status != 0 || !should_strip_debug_symbols) {
-        return status;
-    }
-
-    const char *strip = required_env("LLVM_STRIP");
-    char *strip_args[] = {
-        (char *)strip,
-        "-S",
-        (char *)link_output,
-        NULL,
-    };
-
-    return run_process(strip_args);
+    const char *interface_library_format = required_env("LLVM_INTERFACE_LIBRARY_FORMAT");
+    const char *interface_library_input = required_env("LLVM_INTERFACE_LIBRARY_INPUT");
+    const char *interface_library_output = required_env("LLVM_INTERFACE_LIBRARY_OUTPUT");
+    return generate_interface_library(interface_library_format, interface_library_input, interface_library_output);
 }


### PR DESCRIPTION
Interface libraries are shared library stubs only used during linking.
This can massively reduce the bytes transferred for shared library links
since these stubs only have to contain enough for the public API, not
everything else. Today llvm-ifs does not correctly produce stubs for
defined versioned symbols in a library (which is likely very rare for
bazel). In that case we just copy the original library instead.

Fixes https://github.com/hermeticbuild/hermetic-llvm/issues/219