### PR TITLE
Fix kernel header queries for unavailable architectures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,7 +254,7 @@ jobs:
           restore-keys: |
             bazel-cache-tests-${{ matrix.os }}-${{ matrix.bazel_version }}
 
-      - name: bazel test //tests/...
+      - name: bazel query kernel headers and test //tests/...
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -264,6 +264,14 @@ jobs:
           if [[ -n "${BUILDBUDDY_API_KEY:-}" ]]; then
             REMOTE_HEADER_ARGS=(--remote_header="x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}")
           fi
+
+          bazel \
+            --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc \
+            --bazelrc=.bazelrc \
+            query \
+            "${REMOTE_HEADER_ARGS[@]}" \
+            --output=package \
+            'deps(set(@kernel_headers//:3.6_kernel_headers @kernel_headers//:3.6_kernel_headers_directory @kernel_headers//:4.14_kernel_headers @kernel_headers//:4.14_kernel_headers_directory))'
 
           bazel \
             --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc \

--- a/kernel/extension/kernel_headers.bzl
+++ b/kernel/extension/kernel_headers.bzl
@@ -63,6 +63,21 @@ def _linux_kernel_version_map_content(decoded_index):
 
     lines.append("}")
     lines.append("")
+    lines.append("LINUX_KERNEL_ARCHS_BY_VERSION = {")
+
+    for version in sorted(decoded_index.keys(), key = _version_key, reverse = True):
+        kernel_archs = sorted([
+            kernel_arch
+            for kernel_arch in decoded_index[version]
+            if kernel_arch in _SUPPORTED_ARCHS
+        ])
+        lines.append('    "{}": [{}],'.format(
+            version,
+            ", ".join(['"{}"'.format(kernel_arch) for kernel_arch in kernel_archs]),
+        ))
+
+    lines.append("}")
+    lines.append("")
 
     return "\n".join(lines)
 

--- a/kernel/extension/make_select_kernel_headers_repository_target.bzl
+++ b/kernel/extension/make_select_kernel_headers_repository_target.bzl
@@ -1,4 +1,8 @@
-load("@kernel_headers//:linux_kernel_version_map.bzl", "LINUX_KERNEL_VERSION_MAP")
+load(
+    "@kernel_headers//:linux_kernel_version_map.bzl",
+    "LINUX_KERNEL_ARCHS_BY_VERSION",
+    "LINUX_KERNEL_VERSION_MAP",
+)
 load("//constraints/kernel/linux:linux_kernel_versions.bzl", "LINUX_KERNEL_VERSIONS")
 load("//constraints/libc:libc_versions.bzl", "LIBCS")
 load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
@@ -7,6 +11,9 @@ load(":libc_kernel_versions.bzl", "LIBC_KERNEL_VERSIONS")
 
 def _kernel_headers_repository_target(target_arch, kernel_version, bazel_target):
     return "@linux_kernel_headers_{}.{}//:{}".format(arch_to_kernel_arch(target_arch), kernel_version, bazel_target)
+
+def _kernel_headers_available(target_arch, kernel_version):
+    return arch_to_kernel_arch(target_arch) in LINUX_KERNEL_ARCHS_BY_VERSION.get(kernel_version, [])
 
 def _version_alias_name(kernel_version, bazel_target):
     return "{}_{}".format(kernel_version, bazel_target)
@@ -25,6 +32,8 @@ def _make_select_kernel_headers_repository_target_for_linux_kernel(kernel_versio
     selection = {}
     full_kernel_version = _linux_kernel_headers_version(kernel_version)
     for (target_os, target_arch) in LIBC_SUPPORTED_TARGETS:
+        if not _kernel_headers_available(target_arch, full_kernel_version):
+            continue
         apparent_target = _kernel_headers_repository_target(target_arch, full_kernel_version, bazel_target)
         selection["@llvm//platforms/config:{}_{}".format(target_os, target_arch)] = apparent_target
 
@@ -36,6 +45,8 @@ def _make_select_kernel_headers_repository_target_from_libc(bazel_target):
     for (target_os, target_arch) in LIBC_SUPPORTED_TARGETS:
         for libc_version in LIBCS + ["unconstrained"]:
             kernel_version = LIBC_KERNEL_VERSIONS[libc_version]
+            if not _kernel_headers_available(target_arch, kernel_version):
+                continue
             apparent_target = _kernel_headers_repository_target(target_arch, kernel_version, bazel_target)
             selection["@llvm//platforms/config:{}_{}_{}".format(target_os, target_arch, libc_version)] = apparent_target
 

--- a/tests/kernel_headers/BUILD.bazel
+++ b/tests/kernel_headers/BUILD.bazel
@@ -1,0 +1,5 @@
+load(":kernel_headers_test.bzl", "linux_kernel_archs_by_version_test")
+
+linux_kernel_archs_by_version_test(
+    name = "linux_kernel_archs_by_version_test",
+)

--- a/tests/kernel_headers/kernel_headers_test.bzl
+++ b/tests/kernel_headers/kernel_headers_test.bzl
@@ -1,0 +1,41 @@
+"""Regression tests for the generated Linux kernel header architecture map."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(
+    "@kernel_headers//:linux_kernel_version_map.bzl",
+    "LINUX_KERNEL_ARCHS_BY_VERSION",
+    "LINUX_KERNEL_VERSION_MAP",
+)
+
+def _linux_kernel_archs_by_version_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, "4.14.336", LINUX_KERNEL_VERSION_MAP["4.14"])
+    asserts.equals(
+        env,
+        ["arm", "arm64", "s390", "x86"],
+        LINUX_KERNEL_ARCHS_BY_VERSION["4.14.336"],
+    )
+    asserts.equals(
+        env,
+        ["arm", "arm64", "riscv", "s390", "x86"],
+        LINUX_KERNEL_ARCHS_BY_VERSION["4.15.18"],
+    )
+
+    asserts.equals(env, "3.6.11", LINUX_KERNEL_VERSION_MAP["3.6"])
+    asserts.equals(
+        env,
+        ["arm", "s390", "x86"],
+        LINUX_KERNEL_ARCHS_BY_VERSION["3.6.11"],
+    )
+    asserts.equals(
+        env,
+        ["arm", "arm64", "s390", "x86"],
+        LINUX_KERNEL_ARCHS_BY_VERSION["3.7.10"],
+    )
+
+    return unittest.end(env)
+
+linux_kernel_archs_by_version_test = unittest.make(
+    _linux_kernel_archs_by_version_test_impl,
+)


### PR DESCRIPTION
## Summary

Fix `bazel query` failures for `@linux_kernel_headers_riscv.4.14.336` and other unavailable kernel-header archives. `bazel query` traverses every `select()` branch, including RISC-V and ARM64 repositories that the kernel-header index never creates for older Linux versions.

- Generate `LINUX_KERNEL_ARCHS_BY_VERSION` from the kernel-header archive index.
- Generate explicit-kernel and libc selectors only for existing architecture/version combinations.
- Test the RISC-V 4.14/4.15 and ARM64 3.6/3.7 boundaries.
- Run the original failing dependency queries in the existing Bazel 8 and release-candidate CI matrix.

## Validation

- Original query passes on Bazel 8 and Bazel 9.
- All 8 `//tests/...` tests pass under Linux remote execution.
- Bazel 8 kernel-header regression test passes.
- Changed Bazel and Starlark files pass buildifier.
