### PR TITLE
Build ASan-instrumented libc++ without symbolizer flags

### DIFF
--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@llvm//:directory.bzl", "headers_directory")
@@ -14,7 +15,10 @@ load(
     "weak_symbol_link_flags",
     "weak_symbols_in_sync_tests",
 )
+load("@llvm//constraints/libc:libc_versions.bzl", "LIBCS")
+load("@llvm//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
 load("@llvm//toolchain/args:llvm_target_triple.bzl", "LLVM_TARGET_TRIPLE")
+load("@llvm//toolchain/runtimes:cc_internal_symbolizer_object.bzl", "cc_internal_symbolizer_object")
 load("@llvm//toolchain/runtimes:cc_runtime_shared_library.bzl", "cc_runtime_stage0_shared_library")
 load("@llvm//toolchain/runtimes:cc_runtime_static_library.bzl", "cc_runtime_stage0_static_library")
 load("@llvm//toolchain/runtimes:cc_stage0_object.bzl", "cc_stage0_object")
@@ -808,22 +812,6 @@ cc_runtime_stage0_static_library(
 
 ##### Sanitizers #######
 
-# We want to reset the sanitizer configuration because LLVM builds c++ tools
-# and linking those will lead to errors, as the sanitizer libs is not an linker input.
-# Making it a linker input would result in cycles, and we probably don't want to rebuild
-# a bunch of LLVM code for each different sanitizer configuration anyway.
-
-# Ideally there would be a way to avoid this flag propagating to the exec configuration,
-# but for now this is good enough for now.
-cc_unsanitized_library(
-    name = "llvm_Symbolize",
-    # This is not as terrible as it looks - with the remote repo contents cache, Bazel will be able
-    # to pull down a single ActionResult containing the description of the repo contents, which is enough
-    # to compute AC keys and hopefully get a CAS hit on these deps. So once they're built once, they won't
-    # trigger expensive fetches of llvm-project.
-    dep = "@llvm-project//llvm:Symbolize",
-)
-
 cc_library(
     name = "sanitizers_interface_headers",
     hdrs = glob(["include/sanitizer/*.h"]),
@@ -1294,42 +1282,104 @@ cc_library(
     alwayslink = True,
 )
 
+_INTERNAL_SYMBOLIZER_API = [
+    "__sanitizer_symbolize_code",
+    "__sanitizer_symbolize_data",
+    "__sanitizer_symbolize_frame",
+    "__sanitizer_symbolize_flush",
+    "__sanitizer_symbolize_demangle",
+    "__sanitizer_symbolize_set_demangle",
+    "__sanitizer_symbolize_set_inline_frames",
+]
+
+_INTERNAL_SYMBOLIZER_PLATFORMS = {
+    "@llvm//platforms/config:{}_{}_{}".format(target_os, target_cpu, libc): "@llvm//platforms:{}_{}_{}".format(target_os, target_cpu, libc)
+    for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
+    for libc in LIBCS
+}
+
+_INTERNAL_SYMBOLIZER_PLATFORMS.update({
+    "@llvm//platforms/config:{}_{}_unconstrained".format(target_os, target_cpu): "@llvm//platforms:{}_{}".format(target_os, target_cpu)
+    for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
+})
+
+_INTERNAL_SYMBOLIZER_COPTS = [
+    "-DNDEBUG",
+    "-U_FORTIFY_SOURCE",
+    "-D_FORTIFY_SOURCE=0",
+    "-DHAVE_POSIX_MEMALIGN",
+    "-fPIC",
+    "-flto",
+    "-fno-builtin-memalign",
+    "-fno-stack-protector",
+    "-Oz",
+    "-g0",
+    "-Wno-language-extension-token",
+]
+
+_INTERNAL_SYMBOLIZER_CXXOPTS = [
+    "-D_LIBCPP_ABI_NAMESPACE=__InternalSymbolizer",
+    "-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS",
+    "-D_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS",
+    "-Wno-global-constructors",
+]
+
 cc_library(
-    name = "sanitizer_common_symbolizer_internal",
+    name = "sanitizer_common_symbolizer_internal_impl",
     srcs = [
         "lib/sanitizer_common/symbolizer/sanitizer_symbolize.cpp",
+        "lib/sanitizer_common/symbolizer/sanitizer_wrappers.cpp",
         ":sanitizer_impl_headers_sources",
     ],
-    copts = SANITIZER_CFLAGS + [
-        # The standalone build of the internal symbolizer strips the __cxa_atexit
-        # shim via internalize; do the same explicitly to avoid duplicate symbols
-        # when statically linking against libc implementations that provide it.
-        "-DSANITIZER_SKIP_CXA_ATEXIT_OVERRIDE",
+    copts = [
+        "-include",
+        "compiler-rt/lib/sanitizer_common/sanitizer_redefine_builtins.h",
+        "-DSANITIZER_COMMON_REDEFINE_BUILTINS_IN_STD",
     ],
-    implementation_deps = [
-        ":libcxx_headers",
-        ":sanitizers_interface_headers",
-    ] + select({
-        # sanitizer_symbolize.cpp compiles against LLVM's public headers
-        # (DIPrinter.h ...) and the generated Config/*.h. On macOS the overlay
-        # exposes LLVM's include dirs only through the private llvm_copts, which
-        # does not propagate to dependents, so depend on :config (which carries
-        # includes = ["include"] plus the generated config headers). Other
-        # platforms already find these headers via the existing llvm deps.
-        #
-        # Keep this macOS-only: adding it everywhere fed the generated Config
-        # headers into the path-mapped compile and crashed Bazel 9 (last_rc)
-        # under --experimental_output_paths=strip on this target.
-        "@platforms//os:macos": ["@llvm-project//llvm:config"],
-        "//conditions:default": [],
-    }),
+    implementation_deps = [":sanitizers_interface_headers"],
     includes = [
         "include",
         "lib",
     ],
     deps = [
-        ":llvm_Symbolize",
+        "@llvm-project//llvm:Demangle",
+        "@llvm-project//llvm:Symbolize",
     ],
+    alwayslink = True,
+)
+
+cc_unsanitized_library(
+    name = "sanitizer_common_symbolizer_internal_unsanitized",
+    copts = _INTERNAL_SYMBOLIZER_COPTS,
+    cxxopts = _INTERNAL_SYMBOLIZER_CXXOPTS,
+    dep = ":sanitizer_common_symbolizer_internal_impl",
+    disable_zstd = True,
+    platform = select(_INTERNAL_SYMBOLIZER_PLATFORMS),
+)
+
+cc_internal_symbolizer_object(
+    name = "sanitizer_common_symbolizer_internal_object",
+    out = "sanitizer_common_symbolizer_internal.o",
+    copts = _INTERNAL_SYMBOLIZER_COPTS,
+    cxxopts = _INTERNAL_SYMBOLIZER_CXXOPTS,
+    global_symbols = _INTERNAL_SYMBOLIZER_API,
+    libcxx = "@llvm-project//libcxx:libcxx",
+    libcxxabi = "@llvm-project//libcxxabi:libcxxabi",
+    platform = select(_INTERNAL_SYMBOLIZER_PLATFORMS),
+    symbolizer = ":sanitizer_common_symbolizer_internal_unsanitized",
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    target_triple = LLVM_TARGET_TRIPLE,
+)
+
+cc_library(
+    name = "sanitizer_common_symbolizer_internal",
+    srcs = select({
+        "@platforms//os:linux": [":sanitizer_common_symbolizer_internal_object"],
+        "//conditions:default": [],
+    }) if bazel_features.cc.supports_starlarkified_toolchains else [],
     alwayslink = True,
 )
 
@@ -1541,8 +1591,6 @@ cc_runtime_stage0_static_library(
         ":sanitizer_common_symbolizer",
         ":sanitizer_common_symbolizer_internal",
         ":interception",
-        # if COMPILER_RT_ENABLE_INTERNAL_SYMBOLIZER
-        ":llvm_Symbolize",
     ],
 )
 

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -1292,8 +1292,18 @@ _INTERNAL_SYMBOLIZER_API = [
     "__sanitizer_symbolize_set_inline_frames",
 ]
 
+# Bazel 9 cannot map dotted platform names: https://github.com/bazelbuild/bazel/issues/29314
+[
+    platform(
+        name = "internal_symbolizer_{}_{}_{}".format(target_os, target_cpu, libc.replace(".", "_")),
+        parents = ["@llvm//platforms:{}_{}_{}".format(target_os, target_cpu, libc)],
+    )
+    for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
+    for libc in LIBCS
+]
+
 _INTERNAL_SYMBOLIZER_PLATFORMS = {
-    "@llvm//platforms/config:{}_{}_{}".format(target_os, target_cpu, libc): "@llvm//platforms:{}_{}_{}".format(target_os, target_cpu, libc)
+    "@llvm//platforms/config:{}_{}_{}".format(target_os, target_cpu, libc): ":internal_symbolizer_{}_{}_{}".format(target_os, target_cpu, libc.replace(".", "_"))
     for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
     for libc in LIBCS
 }
@@ -1583,14 +1593,14 @@ cc_runtime_stage0_static_library(
     name = "ubsan_standalone.static",
     visibility = ["//visibility:public"],
     deps = [
-        ":ubsan_preinit",
-        ":ubsan_standalone",
+        ":interception",
         ":sanitizer_common",
-        ":sanitizer_common_libc",
         ":sanitizer_common_coverage",
+        ":sanitizer_common_libc",
         ":sanitizer_common_symbolizer",
         ":sanitizer_common_symbolizer_internal",
-        ":interception",
+        ":ubsan_preinit",
+        ":ubsan_standalone",
     ],
 )
 

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -1304,8 +1304,8 @@ _INTERNAL_SYMBOLIZER_CONSTRAINTS = [
             target_cpu,
             libc.replace(".", "_"),
         ),
-        parents = ["@llvm//platforms:{}_{}_{}".format(target_os, target_cpu, libc)],
         constraint_values = _INTERNAL_SYMBOLIZER_CONSTRAINTS,
+        parents = ["@llvm//platforms:{}_{}_{}".format(target_os, target_cpu, libc)],
     )
     for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
     for libc in LIBCS
@@ -1317,8 +1317,8 @@ _INTERNAL_SYMBOLIZER_CONSTRAINTS = [
             target_os,
             target_cpu,
         ),
-        parents = ["@llvm//platforms:{}_{}".format(target_os, target_cpu)],
         constraint_values = _INTERNAL_SYMBOLIZER_CONSTRAINTS,
+        parents = ["@llvm//platforms:{}_{}".format(target_os, target_cpu)],
     )
     for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
 ]

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -1295,7 +1295,11 @@ _INTERNAL_SYMBOLIZER_API = [
 # Bazel 9 cannot map dotted platform names: https://github.com/bazelbuild/bazel/issues/29314
 [
     platform(
-        name = "internal_symbolizer_{}_{}_{}".format(target_os, target_cpu, libc.replace(".", "_")),
+        name = "internal_symbolizer_{}_{}_{}".format(
+            target_os,
+            target_cpu,
+            libc.replace(".", "_"),
+        ),
         parents = ["@llvm//platforms:{}_{}_{}".format(target_os, target_cpu, libc)],
     )
     for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
@@ -1303,7 +1307,11 @@ _INTERNAL_SYMBOLIZER_API = [
 ]
 
 _INTERNAL_SYMBOLIZER_PLATFORMS = {
-    "@llvm//platforms/config:{}_{}_{}".format(target_os, target_cpu, libc): ":internal_symbolizer_{}_{}_{}".format(target_os, target_cpu, libc.replace(".", "_"))
+    "@llvm//platforms/config:{}_{}_{}".format(target_os, target_cpu, libc): ":internal_symbolizer_{}_{}_{}".format(
+        target_os,
+        target_cpu,
+        libc.replace(".", "_"),
+    )
     for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
     for libc in LIBCS
 }

--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -1292,6 +1292,10 @@ _INTERNAL_SYMBOLIZER_API = [
     "__sanitizer_symbolize_set_inline_frames",
 ]
 
+_INTERNAL_SYMBOLIZER_CONSTRAINTS = [
+    "@llvm//constraints/cxxstdlib:libcxx",
+]
+
 # Bazel 9 cannot map dotted platform names: https://github.com/bazelbuild/bazel/issues/29314
 [
     platform(
@@ -1301,9 +1305,22 @@ _INTERNAL_SYMBOLIZER_API = [
             libc.replace(".", "_"),
         ),
         parents = ["@llvm//platforms:{}_{}_{}".format(target_os, target_cpu, libc)],
+        constraint_values = _INTERNAL_SYMBOLIZER_CONSTRAINTS,
     )
     for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
     for libc in LIBCS
+]
+
+[
+    platform(
+        name = "internal_symbolizer_{}_{}".format(
+            target_os,
+            target_cpu,
+        ),
+        parents = ["@llvm//platforms:{}_{}".format(target_os, target_cpu)],
+        constraint_values = _INTERNAL_SYMBOLIZER_CONSTRAINTS,
+    )
+    for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
 ]
 
 _INTERNAL_SYMBOLIZER_PLATFORMS = {
@@ -1317,7 +1334,7 @@ _INTERNAL_SYMBOLIZER_PLATFORMS = {
 }
 
 _INTERNAL_SYMBOLIZER_PLATFORMS.update({
-    "@llvm//platforms/config:{}_{}_unconstrained".format(target_os, target_cpu): "@llvm//platforms:{}_{}".format(target_os, target_cpu)
+    "@llvm//platforms/config:{}_{}_unconstrained".format(target_os, target_cpu): ":internal_symbolizer_{}_{}".format(target_os, target_cpu)
     for target_os, target_cpu in LIBC_SUPPORTED_TARGETS
 })
 

--- a/3rd_party/llvm-project/x.x/libcxx/libcxx.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libcxx/libcxx.BUILD.bazel
@@ -40,14 +40,6 @@ _CONFIG_SITE_NO_MUSL_LINES = [
     "#define _LIBCPP_HAS_MUSL_LIBC 0",
 ]
 
-_CONFIG_SITE_ASAN_LINES = [
-    "#define _LIBCPP_INSTRUMENTED_WITH_ASAN 1",
-]
-
-_CONFIG_SITE_NO_ASAN_LINES = [
-    "#define _LIBCPP_INSTRUMENTED_WITH_ASAN 0",
-]
-
 _CONFIG_SITE_THREAD_API_WIN32_LINES = [
     "#define _LIBCPP_HAS_THREAD_API_PTHREAD 0",
     "#define _LIBCPP_HAS_THREAD_API_WIN32   1",
@@ -84,6 +76,7 @@ _CONFIG_SITE_GENERIC_LINES = [
     "#define _LIBCPP_HAS_STD_MODULES         0",
     "#define _LIBCPP_HAS_TIME_ZONE_DATABASE  1",
     "#define _LIBCPP_HAS_VENDOR_AVAILABILITY_ANNOTATIONS 0",
+    "#define _LIBCPP_INSTRUMENTED_WITH_ASAN  __has_feature(address_sanitizer)",
     "",
     "#define _LIBCPP_PSTL_BACKEND_SERIAL",
     "// #define _LIBCPP_PSTL_BACKEND_STD_THREAD",
@@ -119,10 +112,6 @@ write_file(
               select({
                   "@platforms//os:windows": _CONFIG_SITE_THREAD_API_WIN32_LINES,
                   "//conditions:default": _CONFIG_SITE_THREAD_API_PTHREAD_LINES,
-              }) +
-              select({
-                  "@llvm//config:asan_enabled": _CONFIG_SITE_ASAN_LINES,
-                  "//conditions:default": _CONFIG_SITE_NO_ASAN_LINES,
               }),
     visibility = ["//visibility:public"],
 )

--- a/3rd_party/llvm-project/x.x/libcxx/libcxx.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libcxx/libcxx.BUILD.bazel
@@ -4,8 +4,8 @@ load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@llvm//3rd_party/llvm-project/21.x/libcxx:libcxx_headers.bzl", "LIBCXX_HEADERS_FILES_21")
 load("@llvm//3rd_party/llvm-project/22.x/libcxx:libcxx_headers.bzl", "LIBCXX_HEADERS_FILES_22")
-load("@llvm//toolchain/runtimes:cc_runtime_shared_library.bzl", "cc_runtime_stage1_shared_library")
-load("@llvm//toolchain/runtimes:cc_runtime_static_library.bzl", "cc_runtime_stage0_static_library")
+load("@llvm//toolchain/runtimes:cc_runtime_shared_library.bzl", "cc_runtime_stage1_asan_shared_library")
+load("@llvm//toolchain/runtimes:cc_runtime_static_library.bzl", "cc_runtime_stage0_asan_static_library")
 load("@llvm-project//:vars.bzl", "LLVM_VERSION_MAJOR")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
@@ -40,6 +40,14 @@ _CONFIG_SITE_NO_MUSL_LINES = [
     "#define _LIBCPP_HAS_MUSL_LIBC 0",
 ]
 
+_CONFIG_SITE_ASAN_LINES = [
+    "#define _LIBCPP_INSTRUMENTED_WITH_ASAN 1",
+]
+
+_CONFIG_SITE_NO_ASAN_LINES = [
+    "#define _LIBCPP_INSTRUMENTED_WITH_ASAN 0",
+]
+
 _CONFIG_SITE_THREAD_API_WIN32_LINES = [
     "#define _LIBCPP_HAS_THREAD_API_PTHREAD 0",
     "#define _LIBCPP_HAS_THREAD_API_WIN32   1",
@@ -56,7 +64,9 @@ _CONFIG_SITE_LIBCPP_VISIBILITY_LINES = [
 
 _CONFIG_SITE_GENERIC_LINES = [
     "#define _LIBCPP_ABI_VERSION             1",
+    "#ifndef _LIBCPP_ABI_NAMESPACE",
     "#define _LIBCPP_ABI_NAMESPACE           __1",
+    "#endif",
     "#define _LIBCPP_ABI_FORCE_ITANIUM       0",
     "#define _LIBCPP_ABI_FORCE_MICROSOFT     0",
     "#define _LIBCPP_HAS_THREADS             1 // TODO: Handle no threads",
@@ -74,7 +84,6 @@ _CONFIG_SITE_GENERIC_LINES = [
     "#define _LIBCPP_HAS_STD_MODULES         0",
     "#define _LIBCPP_HAS_TIME_ZONE_DATABASE  1",
     "#define _LIBCPP_HAS_VENDOR_AVAILABILITY_ANNOTATIONS 0",
-    "#define _LIBCPP_INSTRUMENTED_WITH_ASAN  0",
     "",
     "#define _LIBCPP_PSTL_BACKEND_SERIAL",
     "// #define _LIBCPP_PSTL_BACKEND_STD_THREAD",
@@ -110,6 +119,10 @@ write_file(
               select({
                   "@platforms//os:windows": _CONFIG_SITE_THREAD_API_WIN32_LINES,
                   "//conditions:default": _CONFIG_SITE_THREAD_API_PTHREAD_LINES,
+              }) +
+              select({
+                  "@llvm//config:asan_enabled": _CONFIG_SITE_ASAN_LINES,
+                  "//conditions:default": _CONFIG_SITE_NO_ASAN_LINES,
               }),
     visibility = ["//visibility:public"],
 )
@@ -347,9 +360,10 @@ cc_library(
     ]) + [
         "@llvm-project//libcxxabi:textual_hdrs",
     ],
+    visibility = ["//compiler-rt:__pkg__"],
 )
 
-cc_runtime_stage0_static_library(
+cc_runtime_stage0_asan_static_library(
     name = "libcxx.static",
     visibility = ["//visibility:public"],
     deps = [
@@ -357,7 +371,7 @@ cc_runtime_stage0_static_library(
     ],
 )
 
-cc_runtime_stage1_shared_library(
+cc_runtime_stage1_asan_shared_library(
     name = "libcxx.shared",
     shared_lib_name = "libc++.so.1",
     user_link_flags = [

--- a/3rd_party/llvm-project/x.x/libcxxabi/libcxxabi.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/libcxxabi/libcxxabi.BUILD.bazel
@@ -158,6 +158,7 @@ cc_library(
         "src/**/*.h",
         "src/**/*.def",
     ]),
+    visibility = ["//compiler-rt:__pkg__"],
 )
 
 cc_runtime_stage0_static_library(

--- a/defs.bzl
+++ b/defs.bzl
@@ -14,6 +14,7 @@ def exec_test(*, rule, name, tags = [], args = [], env = {}, data = [], tools = 
         env = env,
         data = data,
         tools = tools,
+        target_compatible_with = kwargs.get("target_compatible_with", []),
     )
 
 def _exec_test_impl(ctx):

--- a/e2e/rules_cc/BUILD.bazel
+++ b/e2e/rules_cc/BUILD.bazel
@@ -62,6 +62,13 @@ _FISSION_TEST_COMPATIBLE = select({
     "//conditions:default": ["@platforms//:incompatible"],
 }) if bazel_features.cc.supports_starlarkified_toolchains else ["@platforms//:incompatible"]
 
+_ASAN_INTERNAL_SYMBOLIZER_SUPPORTED = bazel_features.cc.supports_starlarkified_toolchains
+
+_ASAN_LIBCXX_CONTAINER_OVERFLOW_TEST_COMPATIBLE = select({
+    "@platforms//os:linux": [],
+    "//conditions:default": ["@platforms//:incompatible"],
+}) if _ASAN_INTERNAL_SYMBOLIZER_SUPPORTED else ["@platforms//:incompatible"]
+
 _EXTERNAL_INCLUDE_PATHS_TEST_COMPATIBLE = (
     select({
         "@platforms//os:linux": [],
@@ -769,10 +776,35 @@ asan_cc_binary(
 )
 
 exec_test(
+    name = "asan_libcxx_container_overflow_test",
+    srcs = ["asan_libcxx_container_overflow.cc"],
+    copts = ["-fno-exceptions"],
+    linkopts = ["-Wl,--icf=none"],
+    rule = asan_cc_binary,
+    target_compatible_with = _ASAN_LIBCXX_CONTAINER_OVERFLOW_TEST_COMPATIBLE,
+)
+
+exec_test(
     name = "asan_output_test",
     srcs = ["asan_output_test.sh"],
-    data = [":asan_fail"],
-    env = {"BINARY": "$(rootpath :asan_fail)"},
+    data = [":asan_fail"] + select({
+        "@platforms//os:macos": ["@llvm//tools:llvm-symbolizer"],
+        "@platforms//os:linux": [] if _ASAN_INTERNAL_SYMBOLIZER_SUPPORTED else ["@llvm//tools:llvm-symbolizer"],
+        "//conditions:default": [],
+    }),
+    env = select({
+        "@platforms//os:macos": {
+            "ASAN_SYMBOLIZER_PATH": "$(rootpath @llvm//tools:llvm-symbolizer)",
+            "BINARY": "$(rootpath :asan_fail)",
+        },
+        "@platforms//os:linux": {
+            "BINARY": "$(rootpath :asan_fail)",
+        } if _ASAN_INTERNAL_SYMBOLIZER_SUPPORTED else {
+            "ASAN_SYMBOLIZER_PATH": "$(rootpath @llvm//tools:llvm-symbolizer)",
+            "BINARY": "$(rootpath :asan_fail)",
+        },
+        "//conditions:default": {"BINARY": "$(rootpath :asan_fail)"},
+    }),
     rule = sh_test,
 )
 

--- a/e2e/rules_cc/asan_libcxx_container_overflow.cc
+++ b/e2e/rules_cc/asan_libcxx_container_overflow.cc
@@ -1,0 +1,27 @@
+#include <sys/utsname.h>
+
+#include <iostream>
+#include <string>
+
+std::string get_greet_with_sysinfo(const std::string &who) {
+  std::string greet = "Hello " + std::string{who};
+
+  utsname linux_info{};
+  if (uname(&linux_info) != 0)
+    return greet;
+
+  greet += " (running on Linux kernel: " + std::string(linux_info.release) +
+           " " + linux_info.machine + ")";
+  return greet;
+}
+
+int main(int argc, char **argv) {
+  const std::string who = argc > 1 ? argv[1] : "bazel";
+  const std::string value = get_greet_with_sysinfo(who);
+  std::cout << value << std::endl;
+
+  // basic_string::append must unpoison the short-string storage before
+  // replacing the short representation with the long representation.
+  volatile char terminator = value.c_str()[value.size()];
+  return terminator == '\0' ? 0 : 1;
+}

--- a/e2e/rules_cc/asan_output_test.sh
+++ b/e2e/rules_cc/asan_output_test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 EXPECTED_OUTPUT="ERROR: AddressSanitizer: heap-use-after-free on address"
+EXPECTED_SYMBOLIZED_FRAME="in main"
 
 BIN="$BINARY"
 if [[ ! -x "$BIN" && -n "${RUNFILES_DIR:-}" ]]; then
@@ -26,13 +27,14 @@ trim() {
   echo "$1" | sed 's/[[:space:]]*$//'
 }
 
-if [[ "$(trim "$OUTPUT")" == *"$(trim "$EXPECTED_OUTPUT")"* ]]; then
-  echo "✅ Asan output contains expected string."
+if [[ "$(trim "$OUTPUT")" == *"$(trim "$EXPECTED_OUTPUT")"* && "$OUTPUT" == *"$EXPECTED_SYMBOLIZED_FRAME"* ]]; then
+  echo "✅ ASan output contains the expected error and symbolized frame."
 else
-  echo "❌ Asan output does not contain expected string."
+  echo "❌ ASan output does not contain the expected error and symbolized frame."
   echo
   echo "---- Expected ----"
   printf '%s\n' "$EXPECTED_OUTPUT"
+  printf '%s\n' "$EXPECTED_SYMBOLIZED_FRAME"
   echo "---- Got ----"
   printf '%s\n' "$OUTPUT"
   echo "------------------"

--- a/toolchain/runtimes/BUILD.bazel
+++ b/toolchain/runtimes/BUILD.bazel
@@ -253,6 +253,17 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "cc_internal_symbolizer_object",
+    srcs = ["cc_internal_symbolizer_object.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@rules_cc//cc:action_names_bzl",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
+        "@rules_cc//cc/common",
+    ],
+)
+
 # TODO: Depends on private API that isn't visible
 # bzl_library(
 #     name = "cc_unsanitized_library",

--- a/toolchain/runtimes/cc_internal_symbolizer_object.bzl
+++ b/toolchain/runtimes/cc_internal_symbolizer_object.bzl
@@ -1,0 +1,147 @@
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_TYPE", "find_cc_toolchain", "use_cc_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+
+def _internal_symbolizer_libcxx_transition_impl(settings, attr):
+    return {
+        "//command_line_option:copt": settings["//command_line_option:copt"] + attr.copts,
+        "//command_line_option:cxxopt": settings["//command_line_option:cxxopt"] + attr.cxxopts,
+        "//command_line_option:platforms": str(attr.platform),
+    }
+
+_internal_symbolizer_libcxx_transition = transition(
+    implementation = _internal_symbolizer_libcxx_transition_impl,
+    inputs = [
+        "//command_line_option:copt",
+        "//command_line_option:cxxopt",
+        "//command_line_option:platforms",
+    ],
+    outputs = [
+        "//command_line_option:copt",
+        "//command_line_option:cxxopt",
+        "//command_line_option:platforms",
+    ],
+)
+
+def _link_files(targets):
+    archives = {}
+    objects = {}
+    for target in targets:
+        for linker_input in target[CcInfo].linking_context.linker_inputs.to_list():
+            for library in linker_input.libraries:
+                archive = library.pic_static_library or library.static_library
+                if archive:
+                    archives[archive.path] = archive
+                else:
+                    for object_file in library.pic_objects or library.objects:
+                        objects[object_file.path] = object_file
+    return archives.values(), objects.values()
+
+def _cc_internal_symbolizer_object_impl(ctx):
+    if len(ctx.attr.target_triple) != 1:
+        fail("target_triple must contain exactly one value")
+
+    archives, objects = _link_files(
+        [ctx.attr.symbolizer] + ctx.attr.libcxx + ctx.attr.libcxxabi,
+    )
+    inputs = archives + objects
+    if not inputs:
+        fail("internal symbolizer dependency does not contain linkable files")
+
+    cc_toolchain = find_cc_toolchain(ctx)
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+    )
+    compiler = cc_common.get_tool_for_action(
+        feature_configuration = feature_configuration,
+        action_name = ACTION_NAMES.cpp_link_executable,
+    )
+
+    bitcode = ctx.actions.declare_file(ctx.label.name + ".bc")
+    link_args = ctx.actions.args()
+    link_args.add_all([
+        "-target",
+        ctx.attr.target_triple[0],
+        "-fuse-ld=lld",
+        "-flto",
+        "-nostdlib",
+        "-shared",
+        "-Wl,--lto-emit-llvm",
+        "-Wl,--lto-newpm-passes=internalize",
+        "-Xlinker",
+        "--plugin-opt=-internalize-public-api-list=" + ",".join(ctx.attr.global_symbols),
+    ])
+    link_args.add_all(
+        ctx.attr.global_symbols,
+        format_each = "-Wl,--export-dynamic-symbol=%s",
+    )
+    link_args.add("-Wl,--whole-archive")
+    link_args.add_all(archives)
+    link_args.add("-Wl,--no-whole-archive")
+    link_args.add_all(objects)
+    link_args.add_all(["-o", bitcode])
+    ctx.actions.run(
+        executable = compiler,
+        arguments = [link_args],
+        inputs = inputs,
+        outputs = [bitcode],
+        execution_requirements = {"supports-path-mapping": "1"},
+        mnemonic = "InternalizeSymbolizerBitcode",
+        tools = cc_toolchain.all_files,
+        toolchain = CC_TOOLCHAIN_TYPE,
+    )
+
+    compile_args = ctx.actions.args()
+    compile_args.add_all([
+        "-target",
+        ctx.attr.target_triple[0],
+        "-x",
+        "ir",
+        "-c",
+        "-fno-lto",
+        "-Oz",
+        "-g0",
+        "-fPIC",
+        bitcode,
+        "-o",
+        ctx.outputs.out,
+    ])
+    ctx.actions.run(
+        executable = compiler,
+        arguments = [compile_args],
+        inputs = [bitcode],
+        outputs = [ctx.outputs.out],
+        execution_requirements = {"supports-path-mapping": "1"},
+        mnemonic = "CompileInternalSymbolizerObject",
+        tools = cc_toolchain.all_files,
+        toolchain = CC_TOOLCHAIN_TYPE,
+    )
+
+    return [DefaultInfo(files = depset([ctx.outputs.out]))]
+
+cc_internal_symbolizer_object = rule(
+    implementation = _cc_internal_symbolizer_object_impl,
+    attrs = {
+        "copts": attr.string_list(),
+        "cxxopts": attr.string_list(),
+        "global_symbols": attr.string_list(mandatory = True),
+        "libcxx": attr.label(
+            cfg = _internal_symbolizer_libcxx_transition,
+            mandatory = True,
+            providers = [CcInfo],
+        ),
+        "libcxxabi": attr.label(
+            cfg = _internal_symbolizer_libcxx_transition,
+            mandatory = True,
+            providers = [CcInfo],
+        ),
+        "out": attr.output(mandatory = True),
+        "platform": attr.label(mandatory = True),
+        "symbolizer": attr.label(mandatory = True, providers = [CcInfo]),
+        "target_triple": attr.string_list(mandatory = True),
+    },
+    fragments = ["cpp"],
+    toolchains = use_cc_toolchain(),
+)

--- a/toolchain/runtimes/cc_runtime_shared_library.bzl
+++ b/toolchain/runtimes/cc_runtime_shared_library.bzl
@@ -10,5 +10,11 @@ _builder = with_cfg(
 
 cc_runtime_stage0_shared_library, _cc_stage0_shared_library_internal = configure_builder_for_runtimes(_builder.clone(), "stage0", "dynamic").build()
 cc_runtime_stage1_shared_library, _cc_stage1_shared_library_internal = configure_builder_for_runtimes(_builder.clone(), "stage1", "dynamic").build()
+cc_runtime_stage1_asan_shared_library, _cc_stage1_asan_shared_library_internal = configure_builder_for_runtimes(
+    _builder.clone(),
+    "stage1",
+    "dynamic",
+    inherit_asan = True,
+).build()
 cc_runtime_stage2_shared_library, _cc_stage2_shared_library_internal = configure_builder_for_runtimes(_builder.clone(), "stage2", "dynamic").build()
 cc_runtime_stage3_shared_library, _cc_stage3_shared_library_internal = configure_builder_for_runtimes(_builder.clone(), "stage3", "dynamic").build()

--- a/toolchain/runtimes/cc_runtime_static_library.bzl
+++ b/toolchain/runtimes/cc_runtime_static_library.bzl
@@ -9,3 +9,8 @@ _builder = with_cfg(
 # NOTE: runtime static libraries do not have >stage0 dependencies.
 # Those are only needed for shared libraries.
 cc_runtime_stage0_static_library, _cc_stage0_static_library_internal = configure_builder_for_runtimes(_builder.clone(), "stage0").build()
+cc_runtime_stage0_asan_static_library, _cc_stage0_asan_static_library_internal = configure_builder_for_runtimes(
+    _builder.clone(),
+    "stage0",
+    inherit_asan = True,
+).build()

--- a/toolchain/runtimes/cc_unsanitized_library.bzl
+++ b/toolchain/runtimes/cc_unsanitized_library.bzl
@@ -2,8 +2,12 @@ load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("@rules_cc//cc/private:graph_node_info.bzl", "GraphNodeInfo")  # buildifier: disable=bzl-visibility
 load("@rules_cc//cc/private/rules_impl:cc_shared_library.bzl", "graph_structure_aspect")  # buildifier: disable=bzl-visibility
 
-def _reset_sanitizers_impl(_settings, _attr):
+def _reset_sanitizers_impl(settings, attr):
     return {
+        "//command_line_option:copt": settings["//command_line_option:copt"] + attr.copts,
+        "//command_line_option:cxxopt": settings["//command_line_option:cxxopt"] + attr.cxxopts,
+        "//command_line_option:platforms": str(attr.platform) if attr.platform else settings["//command_line_option:platforms"],
+        "@llvm-project//third-party:llvm_enable_zstd": False if attr.disable_zstd else settings["@llvm-project//third-party:llvm_enable_zstd"],
         "//config:ubsan": False,
         "//config:cfi": False,
         "//config:msan": False,
@@ -36,8 +40,17 @@ def _reset_sanitizers_impl(_settings, _attr):
 
 _reset_sanitizers = transition(
     implementation = _reset_sanitizers_impl,
-    inputs = [],
+    inputs = [
+        "//command_line_option:copt",
+        "//command_line_option:cxxopt",
+        "//command_line_option:platforms",
+        "@llvm-project//third-party:llvm_enable_zstd",
+    ],
     outputs = [
+        "//command_line_option:copt",
+        "//command_line_option:cxxopt",
+        "//command_line_option:platforms",
+        "@llvm-project//third-party:llvm_enable_zstd",
         "//config:ubsan",
         "//config:cfi",
         "//config:msan",
@@ -89,10 +102,14 @@ def _cc_unsanitized_library_impl(ctx):
 cc_unsanitized_library = rule(
     implementation = _cc_unsanitized_library_impl,
     attrs = {
+        "copts": attr.string_list(),
+        "cxxopts": attr.string_list(),
         "dep": attr.label(
             cfg = _reset_sanitizers,
             providers = [CcInfo],
             aspects = [graph_structure_aspect],
         ),
+        "disable_zstd": attr.bool(),
+        "platform": attr.label(),
     },
 )

--- a/toolchain/runtimes/with_cfg_runtimes_common.bzl
+++ b/toolchain/runtimes/with_cfg_runtimes_common.bzl
@@ -1,4 +1,4 @@
-def configure_builder_for_runtimes(builder, runtime_stage, linkmode = "static", sanitizers = False):
+def configure_builder_for_runtimes(builder, runtime_stage, linkmode = "static", sanitizers = False, inherit_asan = False):
     # The problem is that compiler-rt and start libs can only be compiled with
     # a specific set of flags and compilation mode. It is not safe to let the user
     # interfere with them using default command line flags.
@@ -33,7 +33,6 @@ def configure_builder_for_runtimes(builder, runtime_stage, linkmode = "static", 
         builder.set(Label("//config:rtsan"), False)
         builder.set(Label("//config:tysan"), False)
         builder.set(Label("//config:tsan"), False)
-        builder.set(Label("//config:asan"), False)
         builder.set(Label("//config:lsan"), False)
         builder.set(Label("//config:xray"), False)
         builder.set(Label("//config:fuzzer"), False)
@@ -47,10 +46,13 @@ def configure_builder_for_runtimes(builder, runtime_stage, linkmode = "static", 
         builder.set(Label("//config:host_rtsan"), False)
         builder.set(Label("//config:host_tysan"), False)
         builder.set(Label("//config:host_tsan"), False)
-        builder.set(Label("//config:host_asan"), False)
         builder.set(Label("//config:host_lsan"), False)
         builder.set(Label("//config:host_xray"), False)
         builder.set(Label("//config:host_fuzzer"), False)
         builder.set(Label("//config:host_profile"), False)
+
+        if not inherit_asan:
+            builder.set(Label("//config:asan"), False)
+            builder.set(Label("//config:host_asan"), False)
 
     return builder


### PR DESCRIPTION
Author: zbarsky-bot

## Summary

Build the existing `libcxx.static` and `libcxx.shared` with AddressSanitizer when the consuming target enables `//config:asan`. Preserve the existing `stage0` and `stage1` runtime stages and generate `_LIBCPP_INSTRUMENTED_WITH_ASAN` from the existing ASan configuration.

Build compiler-rt's internal symbolizer against the existing `libc++` platform matching the target CPU and libc. Reuse the existing unsanitized LLVM transition and existing `libcxx` and `libcxxabi` targets, disable LLVM's existing Zstandard option, and internalize every definition except the seven `__sanitizer_symbolize_*` entry points. Do not add a public symbolizer flag, a symbolizer-specific `config_setting`, a runtime stage, or a custom `libc++` target.

Preserve the existing sanitizer, coverage, macOS, and `libstdc++` tests. Add the original `std::string` container-overflow regression, require `in main` in ASan diagnostics, and retain the external `llvm-symbolizer` fallback for Bazel 8 and macOS.

## Validation

- [Bazel 9.2 Linux ARM64: ASan container overflow, symbolized ASan output, and existing ASan, UBSan, and LSan runtime tests](https://app.buildbuddy.io/invocation/860314e8-54ed-4800-a2d8-cd5346533cd2).
- [Bazel 8.7 Linux ARM64: external-symbolizer ASan output and existing ASan, UBSan, and LSan runtime tests](https://app.buildbuddy.io/invocation/755e5062-e3b3-4d9e-a8e6-030185a22d4f).
- [Existing Linux ARM64 `libstdc++` binary, header, and explicit-link-option targets](https://app.buildbuddy.io/invocation/e06d5d27-3031-407c-b260-9eb47af1f1b3).
- [Linux x86_64 ASan, container-overflow, and existing `libstdc++` cross-compilation](https://app.buildbuddy.io/invocation/bba8e79a-648d-4095-badf-c642f89531da).
- `buildifier -mode=check`, `git diff --check`, and `bash -n e2e/rules_cc/asan_output_test.sh`.
