### PR TITLE
Fix non-hermetic golang strip targeting macOS

### DIFF
--- a/tests/cgo/BUILD.bazel
+++ b/tests/cgo/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_go//go:def.bzl", "go_binary")
-load(":defs.bzl", "force_pic_go_binary")
+load(":defs.bzl", "force_pic_go_binary", "macos_arm64_debug_go_binary")
 
 go_binary(
     name = "hello_cgo",
@@ -23,6 +23,17 @@ platform_transition_binary(
 build_test(
     name = "hello_cgo_x86_64_musl_test",
     targets = [":hello_cgo_x86_64_musl"],
+)
+
+macos_arm64_debug_go_binary(
+    name = "hello_cgo_macos_arm64",
+    srcs = ["hello.go"],
+    cgo = True,
+)
+
+build_test(
+    name = "hello_cgo_macos_arm64_test",
+    targets = [":hello_cgo_macos_arm64"],
 )
 
 force_pic_go_binary(

--- a/tests/cgo/defs.bzl
+++ b/tests/cgo/defs.bzl
@@ -8,3 +8,14 @@ force_pic_go_binary, _force_pic_go_binary_internal = with_cfg(
     "force_pic",
     True,
 ).build()
+
+macos_arm64_debug_go_binary, _macos_arm64_debug_go_binary_internal = with_cfg(
+    go_binary,
+    executable = True,
+).set(
+    "platforms",
+    [Label("@llvm//platforms:macos_arm64")],
+).set(
+    "strip",
+    "never",
+).build()

--- a/tools/internal/link_wrapper.c
+++ b/tools/internal/link_wrapper.c
@@ -132,6 +132,38 @@ static const char *required_env(const char *name) {
     return value;
 }
 
+// Go's external linker discovers Darwin post-link tools through the compiler driver.
+// Return the tools supplied by the cc_tool instead of falling back to the host PATH.
+static int maybe_print_hermetic_tool(int argc, char **argv) {
+    const char *tool_name = NULL;
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--print-prog-name") == 0 && i + 1 < argc) {
+            tool_name = argv[i + 1];
+            break;
+        }
+
+        static const char prefix[] = "--print-prog-name=";
+        if (strncmp(argv[i], prefix, sizeof(prefix) - 1) == 0) {
+            tool_name = argv[i] + sizeof(prefix) - 1;
+            break;
+        }
+    }
+
+    const char *env_name = NULL;
+    if (tool_name != NULL) {
+        if (strcmp(tool_name, "dsymutil") == 0) {
+            env_name = "LLVM_DSYMUTIL";
+        } else if (strcmp(tool_name, "strip") == 0) {
+            env_name = "LLVM_STRIP";
+        }
+    }
+    if (env_name == NULL) {
+        return -1;
+    }
+
+    return printf("%s\n", required_env(env_name)) < 0 ? 1 : 0;
+}
+
 static int copy_file(const char *source_path, const char *destination_path) {
     FILE *source = fopen(source_path, "rb");
     if (source == NULL) {
@@ -260,7 +292,10 @@ static int generate_interface_library(const char *format, const char *input_path
 }
 
 int main(int argc, char **argv) {
-    (void)argc;
+    int print_tool_status = maybe_print_hermetic_tool(argc, argv);
+    if (print_tool_status >= 0) {
+        return print_tool_status;
+    }
 
     const char *clangxx = required_env("LLVM_CLANGXX");
     const char *strip_debug_symbols = getenv("LLVM_STRIP_DEBUG_SYMBOLS");


### PR DESCRIPTION
Previously this fell back to using /bin/strip on linux, which likely
doesn't support stripping Mach-O binaries. It shouldn't be using a
system binary for this anyways.

The `/bin/strip` path comes from golang calling
`<linker driver> --print-prog-name strip`, so now we return the correct
value for this
