### PR TITLE
Fix internal symbolizer sandbox input collision

### DIFF
--- a/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
+++ b/3rd_party/llvm-project/x.x/compiler-rt/compiler-rt.BUILD.bazel
@@ -1371,7 +1371,6 @@ cc_library(
         "compiler-rt/lib/sanitizer_common/sanitizer_redefine_builtins.h",
         "-DSANITIZER_COMMON_REDEFINE_BUILTINS_IN_STD",
     ],
-    implementation_deps = [":sanitizers_interface_headers"],
     includes = [
         "include",
         "lib",


### PR DESCRIPTION
## Summary

Remove the unused `:sanitizers_interface_headers` dependency from `sanitizer_common_symbolizer_internal_impl`. The complete-stage toolchain already stages `compiler-rt/include`; the additional dependency stages individual files under the same directory, causing local and dynamic Bazel sandbox builds to fail with `compiler-rt/include (File exists)`.

Keep the public `sanitizers_interface_headers` target and its 10 consumers, including LLVM libc and libunwind. The runtime-stage guard from #671 cannot fix this target because `cc_unsanitized_library` compiles the internal symbolizer with `runtime_stage=complete`.

Reported in https://github.com/hermeticbuild/hermetic-llvm/pull/666#issuecomment-5093553506.

## Validation

Reproduced the original failure and verified the fix against the exact internal symbolizer target with remote execution, remote cache, remote downloader, and BES disabled:

```bash
bazel build \
  --remote_executor= \
  --remote_cache= \
  --experimental_remote_downloader= \
  --bes_backend= \
  --spawn_strategy=processwrapper-sandbox \
  --strategy=CppCompile=processwrapper-sandbox \
  --jobs=2 \
  --platforms=@llvm//platforms:linux_aarch64_gnu.2.28 \
  --per_file_copt='sanitizer_wrappers[.]cpp@-DCODEX_LOCAL_SANDBOX_REPRO_20260727=1' \
  @llvm-project//compiler-rt:sanitizer_common_symbolizer_internal_unsanitized
```

The unmodified target fails with the reported sandbox error; the fix succeeds with 83 locally sandboxed actions. Buildifier 8.5.1 and `git diff --check` also pass.

Requested reviewer: @cerisier.