### PR TITLE
Fix hermetic macOS cgo stripping with COMPILER_PATH

### DIFF
--- a/tests/cgo/BUILD.bazel
+++ b/tests/cgo/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_lib//lib:transitions.bzl", "platform_transition_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_go//go:def.bzl", "go_binary")
-load(":defs.bzl", "force_pic_go_binary")
+load(":defs.bzl", "force_pic_go_binary", "macos_arm64_debug_go_binary")
 
 go_binary(
     name = "hello_cgo",
@@ -23,6 +23,17 @@ platform_transition_binary(
 build_test(
     name = "hello_cgo_x86_64_musl_test",
     targets = [":hello_cgo_x86_64_musl"],
+)
+
+macos_arm64_debug_go_binary(
+    name = "hello_cgo_macos_arm64",
+    srcs = ["hello.go"],
+    cgo = True,
+)
+
+build_test(
+    name = "hello_cgo_macos_arm64_test",
+    targets = [":hello_cgo_macos_arm64"],
 )
 
 force_pic_go_binary(

--- a/tests/cgo/defs.bzl
+++ b/tests/cgo/defs.bzl
@@ -8,3 +8,14 @@ force_pic_go_binary, _force_pic_go_binary_internal = with_cfg(
     "force_pic",
     True,
 ).build()
+
+macos_arm64_debug_go_binary, _macos_arm64_debug_go_binary_internal = with_cfg(
+    go_binary,
+    executable = True,
+).set(
+    "platforms",
+    [Label("@llvm//platforms:macos_arm64")],
+).set(
+    "strip",
+    "never",
+).build()

--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -199,6 +199,7 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
     )
 
     for tool in [
+        "llvm",
         "llvm-ifs",
         "llvm-nm",
         "llvm-readtapi",
@@ -306,6 +307,7 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
             "@rules_cc//cc/toolchains/capabilities:supports_interface_shared_libraries",
         ],
         env = {
+            "COMPILER_PATH": "{llvm}-",
             "LLVM_CLANGXX": "{clangxx}",
             "LLVM_DSYMUTIL": "{dsymutil}",
             "LLVM_IFS": "{llvm_ifs}",
@@ -316,6 +318,7 @@ def declare_tool_map(exec_os, exec_cpu, prefix = None, fdo_profile = None, fdo_i
         format = {
             "clangxx": prefix + "/bin/clang++",
             "dsymutil": prefix + "/bin/dsymutil",
+            "llvm": prefix + "/bin/llvm",
             "llvm_ifs": prefix + "/bin/llvm-ifs",
             "llvm_nm": prefix + "/bin/llvm-nm",
             "llvm_readtapi": prefix + "/bin/llvm-readtapi",

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -21,6 +21,11 @@ def declare_llvm_targets(*, suffix = ""):
     native.exports_files(native.glob(["bin/*"]))
 
     native.filegroup(
+        name = "llvm_bin_directory",
+        srcs = ["bin"],
+    )
+
+    native.filegroup(
         name = "clangxx_file",
         srcs = ["bin/clang++" + suffix],
     )
@@ -243,6 +248,7 @@ def declare_llvm_targets(*, suffix = ""):
             "@rules_cc//cc/toolchains/capabilities:supports_interface_shared_libraries",
         ],
         env = {
+            "COMPILER_PATH": "{llvm_bin}/llvm-",
             "LLVM_CLANGXX": "{clangxx}",
             "LLVM_DSYMUTIL": "{dsymutil}",
             "LLVM_IFS": "{llvm_ifs}",
@@ -253,6 +259,7 @@ def declare_llvm_targets(*, suffix = ""):
         format = {
             "clangxx": ":clangxx_file",
             "dsymutil": ":dsymutil_file",
+            "llvm_bin": ":llvm_bin_directory",
             "llvm_ifs": "bin/llvm-ifs" + suffix,
             "llvm_nm": "bin/llvm-nm" + suffix,
             "llvm_readtapi": "bin/llvm-readtapi" + suffix,


### PR DESCRIPTION
Alternative to #687 using the same macOS cgo regression test.

Go discovers Darwin post-link tools by invoking the external linker with `--print-prog-name strip`, without passing external linker flags. Set `COMPILER_PATH` to the hermetic LLVM `llvm-` prefix for prebuilt and bootstrapped toolchains so Clang resolves `llvm-strip` itself. This leaves `tools/internal/link_wrapper.c` unchanged.

`COMPILER_PATH` is not GCC-only: [LLVM 22.1.8 Clang adds both `-B` and `COMPILER_PATH` to the same `PrefixDirs`](https://github.com/llvm/llvm-project/blob/llvmorg-22.1.8/clang/lib/Driver/Driver.cpp#L1612-L1623). Resolve the prebuilt prefix from the `bin` directory so Windows `llvm.exe` does not produce an invalid `llvm.exe-` prefix. Add the existing `llvm` multicall executable to the bootstrap tool declarations for the same lookup in bootstrapped toolchains.

Validation:

- `bazel test --config=remote --remote_download_outputs=minimal --jobs=128 --lockfile_mode=off //tests/cgo/...`: all six tests pass, including `hello_cgo_macos_arm64_test`.
- [Remote test run](https://app.buildbuddy.io/invocation/1ab2b2f0-0781-4ddc-9d9e-b3a9a33ea326).
- Buildifier and `git diff --check` pass.