### PR TITLE
Add freestanding PPC64LE and architecture-aware libc defaults

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -274,6 +274,11 @@ jobs:
             --remote_header=x-buildbuddy-api-key=4jtaxdhxtyu4ylxdEwI7 \
             //tests/...
 
+          BAZEL_REMOTE_HEADER=x-buildbuddy-api-key=4jtaxdhxtyu4ylxdEwI7 \
+            bash tests/freestanding/check_ppc64le_toolchain.sh \
+            --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc \
+            --bazelrc=.bazelrc
+
   docs:
     runs-on: macos-15-intel
     name: Verify public docs generation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,7 +275,7 @@ jobs:
             //tests/...
 
           BAZEL_REMOTE_HEADER=x-buildbuddy-api-key=4jtaxdhxtyu4ylxdEwI7 \
-            bash tests/freestanding/check_ppc64le_toolchain.sh \
+            bash tests/check_linux_architecture_contracts.sh \
             --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc \
             --bazelrc=.bazelrc
 

--- a/3rd_party/libc/glibc/BUILD.bazel
+++ b/3rd_party/libc/glibc/BUILD.bazel
@@ -6,4 +6,8 @@ bzl_library(
     name = "helpers",
     srcs = ["helpers.bzl"],
     visibility = ["//visibility:public"],
+    deps = [
+        "//constraints/libc:libc_versions",
+        "//platforms:common",
+    ],
 )

--- a/3rd_party/libc/glibc/glibc.BUILD.bazel
+++ b/3rd_party/libc/glibc/glibc.BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@llvm//3rd_party/libc/glibc:helpers.bzl", "glibc_includes")
+load("@llvm//3rd_party/libc/glibc:helpers.bzl", "glibc_includes", "glibc_version_config_settings")
 load("@llvm//toolchain/args:llvm_target_triple.bzl", "LLVM_TARGET_TRIPLE")
 load("@llvm//toolchain/runtimes:cc_runtime_library.bzl", "cc_runtime_stage0_library")
 load("@llvm//toolchain/runtimes:cc_runtime_static_library.bzl", "cc_runtime_stage0_static_library")
@@ -220,18 +220,14 @@ cc_runtime_stage0_library(
         # From debug/Makefile
         "debug/stack_chk_fail_local.c",
     ] + selects.with_or({
-        (
-            # For now the minimum version of all supported platforms is glibc 2.28
-            #
-            # unconstrained defaults to 2.28
+        glibc_version_config_settings([
             # TODO(cerisier): Make a is_at_least_gnu_version macro helper.
-            "@llvm//constraints/libc:unconstrained",
-            "@llvm//constraints/libc:gnu.2.28",
-            "@llvm//constraints/libc:gnu.2.29",
-            "@llvm//constraints/libc:gnu.2.30",
-            "@llvm//constraints/libc:gnu.2.31",
-            "@llvm//constraints/libc:gnu.2.32",
-        ): [
+            "gnu.2.28",
+            "gnu.2.29",
+            "gnu.2.30",
+            "gnu.2.31",
+            "gnu.2.32",
+        ]): [
             # libc_nonshared.a redirected stat functions to xstat until glibc 2.33,
             # when they were finally versioned like other symbols.
 
@@ -251,7 +247,7 @@ cc_runtime_stage0_library(
             # From csu/Makefile
             "@llvm//3rd_party/libc/glibc/csu:elf-init-2.31.c",
         ],
-        "@llvm//constraints/libc:gnu.2.33": [
+        glibc_version_config_settings(["gnu.2.33"]): [
             # if libc <= 2.32 but also <= 2.33
             # __libc_start_main used to require statically linked init/fini callbacks
             # until glibc 2.34 when they were assimilated into the shared library.

--- a/3rd_party/libc/glibc/helpers.bzl
+++ b/3rd_party/libc/glibc/helpers.bzl
@@ -1,3 +1,17 @@
+load("//constraints/libc:libc_versions.bzl", "resolve_libc")
+load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
+
+def glibc_version_config_settings(glibc_versions):
+    """Returns config settings whose effective glibc is in glibc_versions."""
+    return tuple([
+        "@llvm//constraints/libc:{}".format(glibc_version)
+        for glibc_version in glibc_versions
+    ] + [
+        "@llvm//platforms/config:{}_{}_unconstrained".format(target_os, target_cpu)
+        for (target_os, target_cpu) in LIBC_SUPPORTED_TARGETS
+        if resolve_libc(target_os, target_cpu, "unconstrained") in glibc_versions
+    ])
+
 # A good starting point for this is https://codeberg.org/ziglang/zig/src/branch/master/src/libs/glibc.zig add_include_dirs function
 def glibc_includes(cpu):
     os_abi_variant = []

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,13 @@ exports_files([
     ".buildifier.json",
 ])
 
+bzl_library(
+    name = "host_tools_repository",
+    srcs = ["host_tools_repository.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//extensions:llvm_host_tools_repository"],
+)
+
 alias(
     name = "rbe_platform",
     actual = "@rbe_platform//:rbe_platform",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -94,6 +94,7 @@ llvm.configure(
         "ARM",
         "BPF",
         "NVPTX",
+        "PowerPC",
         "RISCV",
         "SystemZ",
         "WebAssembly",

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ toolchain.exec(arch = "x86_64", os = "linux")
 toolchain.exec(arch = "aarch64", os = "linux")
 toolchain.target(arch = "x86_64", os = "linux")
 toolchain.target(arch = "aarch64", os = "linux")
+toolchain.target(arch = "ppc64le", os = "linux")
 toolchain.target(arch = "riscv64", os = "linux")
 
 use_repo(toolchain, "llvm_toolchains")
@@ -71,11 +72,38 @@ register_toolchains("@llvm_toolchains//:all")
 
 This registers the cross-product of the specified exec and target platforms.
 
+The PPC64LE target is freestanding: it provides the compiler, assembler,
+linker, and builtin headers without selecting a libc, CRT, C++ runtime, or
+hosted compiler runtime. This is suitable for kernels and other freestanding
+programs, but not hosted Linux applications.
+
 If you need finer control, register individual toolchain targets. You can list them with:
 
 ```sh
 bazel query 'kind(toolchain, @llvm//toolchain:all)'
 ```
+
+### Repository-time LLVM host tools
+
+Repository rules that need a host-native `clang` and `ld.lld` can instantiate
+the integrity-pinned minimal-tools repository:
+
+```starlark
+llvm_host_tools_repository = use_repo_rule(
+    "@llvm//:host_tools_repository.bzl",
+    "llvm_host_tools_repository",
+)
+
+llvm_host_tools_repository(
+    name = "llvm_host_tools",
+    llvm_version = "22.1.8",
+)
+```
+
+The repository exports stable `:clang.exe` and `:ld.lld.exe` probe labels on
+every host, compatibility labels `:clang` and `:ld.lld`, and the
+`host-platform.txt`, `llvm-host-tools.json`, and `resource-dir.txt` metadata
+files.
 
 ### Cgo compatibility
 To make the vanilla Go compiler work with a fully hermetic toolchain, we had to send some patches upstream. Only versions of Go >= 1.27 are supported out of the box.
@@ -119,6 +147,7 @@ If you wish to setup things manually, you will likely require a few flags:
 | **aarch64-linux-gnu ¹**  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **x86_64-linux-gnu ¹**   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **riscv64-linux-gnu ¹**   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **powerpc64le-linux-gnu ³** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **s390x-linux-gnu ¹**     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **armv7-linux-gnueabihf ¹** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **aarch64-linux-musl**   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -136,6 +165,9 @@ If you wish to setup things manually, you will likely require a few flags:
 ¹ See "GNU C Library" section for glibc version selection.
 
 ² See "Windows" section.
+
+³ Freestanding compiler, assembler, linker, and builtin headers only; no libc,
+CRT, C++ runtime, or hosted compiler runtime.
 
 ### musl
 
@@ -237,6 +269,13 @@ We use a cross-platform reimplementation of `pkgutil` to unpack SDK packages, wh
 For now, RISC-V support is limited to Linux and currently hard-wired to the
 rv64gc ISA and lp64d ABI while we work out a clean way to configure freestanding
 targets and ISA matrices.
+
+### PowerPC64LE
+
+Linux PPC64LE is currently freestanding. A platform containing only
+`@platforms//os:linux` and `@platforms//cpu:ppc64le` selects the
+`powerpc64le-linux-gnu` compiler and linker surface without hosted runtime
+dependencies.
 
 ### Other platforms
 

--- a/constraints/cxxstdlib/BUILD.bazel
+++ b/constraints/cxxstdlib/BUILD.bazel
@@ -9,6 +9,11 @@ constraint_setting(
     default_constraint_value = DEFAULT_CXXSTDLIB,
 )
 
+constraint_value(
+    name = "none",
+    constraint_setting = "variant",
+)
+
 [
     constraint_value(
         name = cxxstdlib,

--- a/constraints/libc/libc_versions.bzl
+++ b/constraints/libc/libc_versions.bzl
@@ -32,3 +32,10 @@ DEFAULT_LIBCS = {
 
 def default_libc(target_os, target_cpu):
     return DEFAULT_LIBCS.get((target_os, target_cpu), DEFAULT_LIBC)
+
+def resolve_libc(target_os, target_cpu, libc):
+    """Resolves the libc constraint value for a target platform."""
+    if libc == "unconstrained":
+        return default_libc(target_os, target_cpu)
+
+    return libc

--- a/extensions/BUILD.bazel
+++ b/extensions/BUILD.bazel
@@ -33,6 +33,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "llvm_host_tools_repository",
+    srcs = ["llvm_host_tools_repository.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
     name = "osx",
     srcs = ["osx.bzl"],
     visibility = ["//visibility:public"],

--- a/extensions/BUILD.bazel
+++ b/extensions/BUILD.bazel
@@ -36,6 +36,16 @@ bzl_library(
     name = "llvm_host_tools_repository",
     srcs = ["llvm_host_tools_repository.bzl"],
     visibility = ["//visibility:public"],
+    deps = [":llvm_host_tools_paths"],
+)
+
+bzl_library(
+    name = "llvm_host_tools_paths",
+    srcs = ["llvm_host_tools_paths.bzl"],
+    visibility = [
+        "//extensions:__pkg__",
+        "//tests/host_tools:__pkg__",
+    ],
 )
 
 bzl_library(

--- a/extensions/llvm_host_tools_paths.bzl
+++ b/extensions/llvm_host_tools_paths.bzl
@@ -1,0 +1,34 @@
+"""Host-specific archive paths and stable repository paths for LLVM probe tools."""
+
+def llvm_host_tools_layout(archive_target):
+    """Returns the archive and generated repository paths for host LLVM tools.
+
+    The compatibility paths keep the original public labels stable. The probe
+    paths deliberately retain a `.exe` suffix on every host: Unix can execute
+    those symlinks directly, while Windows process launchers require the suffix
+    when they receive an absolute path.
+    """
+    archive_suffix = ".exe" if archive_target.startswith("windows-") else ""
+    archive_paths = {
+        "clang": "bin/clang" + archive_suffix,
+        "ld_lld": "bin/ld.lld" + archive_suffix,
+    }
+    compatibility_paths = {
+        "clang": "clang",
+        "ld_lld": "ld.lld",
+    }
+    probe_paths = {
+        "clang": "clang.exe",
+        "ld_lld": "ld.lld.exe",
+    }
+    return struct(
+        archive_paths = archive_paths,
+        compatibility_paths = compatibility_paths,
+        probe_paths = probe_paths,
+        root_symlinks = {
+            compatibility_paths["clang"]: archive_paths["clang"],
+            compatibility_paths["ld_lld"]: archive_paths["ld_lld"],
+            probe_paths["clang"]: archive_paths["clang"],
+            probe_paths["ld_lld"]: archive_paths["ld_lld"],
+        },
+    )

--- a/extensions/llvm_host_tools_paths.bzl
+++ b/extensions/llvm_host_tools_paths.bzl
@@ -7,6 +7,12 @@ def llvm_host_tools_layout(archive_target):
     paths deliberately retain a `.exe` suffix on every host: Unix can execute
     those symlinks directly, while Windows process launchers require the suffix
     when they receive an absolute path.
+
+    Args:
+        archive_target: The release archive target identifier.
+
+    Returns:
+        A struct containing archive, compatibility, probe, and symlink paths.
     """
     archive_suffix = ".exe" if archive_target.startswith("windows-") else ""
     archive_paths = {

--- a/extensions/llvm_host_tools_paths.bzl
+++ b/extensions/llvm_host_tools_paths.bzl
@@ -1,5 +1,44 @@
 """Host-specific archive paths and stable repository paths for LLVM probe tools."""
 
+_HOST_ARCHES = {
+    "aarch64": "arm64",
+    "amd64": "amd64",
+    "arm64": "arm64",
+    "x86_64": "amd64",
+}
+
+_HOST_OSES = {
+    "linux": "linux",
+    "mac os x": "darwin",
+    "macos": "darwin",
+    "windows": "windows",
+}
+
+def llvm_host_tools_archive_target(os_name, arch):
+    """Returns the minimal LLVM archive target for a repository host.
+
+    Args:
+        os_name: Host operating-system name reported by Bazel.
+        arch: Host architecture name reported by Bazel.
+
+    Returns:
+        The matching minimal LLVM release archive target.
+    """
+    normalized_os = os_name.lower()
+    if normalized_os.startswith("windows"):
+        normalized_os = "windows"
+
+    host_os = _HOST_OSES.get(normalized_os)
+    host_arch = _HOST_ARCHES.get(arch.lower())
+    if host_os == None or host_arch == None:
+        fail("Unsupported LLVM host platform: os='{}', arch='{}'".format(
+            os_name,
+            arch,
+        ))
+
+    suffix = "-musl" if host_os == "linux" else ""
+    return "{}-{}{}".format(host_os, host_arch, suffix)
+
 def llvm_host_tools_layout(archive_target):
     """Returns the archive and generated repository paths for host LLVM tools.
 

--- a/extensions/llvm_host_tools_repository.bzl
+++ b/extensions/llvm_host_tools_repository.bzl
@@ -1,34 +1,15 @@
 """Repository rule for integrity-pinned LLVM tools used during repository evaluation."""
 
-load(":llvm_host_tools_paths.bzl", "llvm_host_tools_layout")
+load(
+    ":llvm_host_tools_paths.bzl",
+    "llvm_host_tools_archive_target",
+    "llvm_host_tools_layout",
+)
 
 DEFAULT_LLVM_TOOLCHAIN_MINIMAL_INDEX_FILE = "//extensions:llvm_toolchain_minimal_index.json"
 
-_HOST_ARCHES = {
-    "aarch64": "arm64",
-    "amd64": "amd64",
-    "arm64": "arm64",
-    "x86_64": "amd64",
-}
-
-_HOST_OSES = {
-    "linux": "linux",
-    "mac os x": "darwin",
-    "macos": "darwin",
-    "windows": "windows",
-}
-
 def _host_archive_target(rctx):
-    host_os = _HOST_OSES.get(rctx.os.name.lower())
-    host_arch = _HOST_ARCHES.get(rctx.os.arch.lower())
-    if host_os == None or host_arch == None:
-        fail("Unsupported LLVM host platform: os='{}', arch='{}'".format(
-            rctx.os.name,
-            rctx.os.arch,
-        ))
-
-    suffix = "-musl" if host_os == "linux" else ""
-    return "{}-{}{}".format(host_os, host_arch, suffix)
+    return llvm_host_tools_archive_target(rctx.os.name, rctx.os.arch)
 
 def _release_key(index, llvm_version, requested_release):
     if requested_release:

--- a/extensions/llvm_host_tools_repository.bzl
+++ b/extensions/llvm_host_tools_repository.bzl
@@ -71,6 +71,11 @@ def _llvm_host_tools_repository_impl(rctx):
         "release": release,
     }
     rctx.file("llvm-host-tools.json", json.encode_indent(identity, indent = "  ") + "\n")
+    rctx.file(
+        "host-platform.txt",
+        "{}/{}\n".format(rctx.os.name, rctx.os.arch),
+        executable = False,
+    )
     rctx.file("resource-dir.txt", resource_dir + "\n")
     rctx.file(
         "BUILD.bazel",
@@ -78,6 +83,7 @@ def _llvm_host_tools_repository_impl(rctx):
 package(default_visibility = ["//visibility:public"])
 
 exports_files({root_files} + [
+    "host-platform.txt",
     "llvm-host-tools.json",
     "resource-dir.txt",
 ])

--- a/extensions/llvm_host_tools_repository.bzl
+++ b/extensions/llvm_host_tools_repository.bzl
@@ -1,5 +1,7 @@
 """Repository rule for integrity-pinned LLVM tools used during repository evaluation."""
 
+load(":llvm_host_tools_paths.bzl", "llvm_host_tools_layout")
+
 DEFAULT_LLVM_TOOLCHAIN_MINIMAL_INDEX_FILE = "//extensions:llvm_toolchain_minimal_index.json"
 
 _HOST_ARCHES = {
@@ -57,9 +59,9 @@ def _llvm_host_tools_repository_impl(rctx):
         sha256 = archive["sha256"],
     )
 
-    executable_suffix = ".exe" if archive_target.startswith("windows-") else ""
-    clang = "bin/clang" + executable_suffix
-    ld_lld = "bin/ld.lld" + executable_suffix
+    layout = llvm_host_tools_layout(archive_target)
+    clang = layout.archive_paths["clang"]
+    ld_lld = layout.archive_paths["ld_lld"]
     resource_dir = "lib/clang/{}".format(rctx.attr.llvm_version.partition(".")[0])
 
     for tool in [clang, ld_lld]:
@@ -68,10 +70,12 @@ def _llvm_host_tools_repository_impl(rctx):
     if not rctx.path(resource_dir).exists:
         fail("Minimal LLVM archive '{}' is missing {}".format(release, resource_dir))
 
-    # Stable root labels let downstream repository rules use repository_ctx.path
-    # without reproducing host-specific executable suffix logic.
-    rctx.symlink(clang, "clang")
-    rctx.symlink(ld_lld, "ld.lld")
+    # Keep the original root labels for compatibility, and expose suffix-bearing
+    # paths for repository rules that pass absolute tool paths to native process
+    # launchers. The latter must end in .exe on Windows; making them available on
+    # every host gives consumers one portable pair of labels.
+    for root_path in sorted(layout.root_symlinks):
+        rctx.symlink(layout.root_symlinks[root_path], root_path)
 
     identity = {
         "archive_sha256": archive["sha256"],
@@ -82,6 +86,7 @@ def _llvm_host_tools_repository_impl(rctx):
             "ld_lld": ld_lld,
             "resource_dir": resource_dir,
         },
+        "probe_paths": layout.probe_paths,
         "release": release,
     }
     rctx.file("llvm-host-tools.json", json.encode_indent(identity, indent = "  ") + "\n")
@@ -91,9 +96,7 @@ def _llvm_host_tools_repository_impl(rctx):
         """\
 package(default_visibility = ["//visibility:public"])
 
-exports_files([
-    "clang",
-    "ld.lld",
+exports_files({root_files} + [
     "llvm-host-tools.json",
     "resource-dir.txt",
 ])
@@ -109,6 +112,7 @@ filegroup(
 )
 """.format(
             resource_glob = repr(resource_dir + "/**"),
+            root_files = repr(sorted(layout.root_symlinks.keys())),
         ),
     )
 

--- a/extensions/llvm_host_tools_repository.bzl
+++ b/extensions/llvm_host_tools_repository.bzl
@@ -1,0 +1,137 @@
+"""Repository rule for integrity-pinned LLVM tools used during repository evaluation."""
+
+DEFAULT_LLVM_TOOLCHAIN_MINIMAL_INDEX_FILE = "//extensions:llvm_toolchain_minimal_index.json"
+
+_HOST_ARCHES = {
+    "aarch64": "arm64",
+    "amd64": "amd64",
+    "arm64": "arm64",
+    "x86_64": "amd64",
+}
+
+_HOST_OSES = {
+    "linux": "linux",
+    "mac os x": "darwin",
+    "macos": "darwin",
+    "windows": "windows",
+}
+
+def _host_archive_target(rctx):
+    host_os = _HOST_OSES.get(rctx.os.name.lower())
+    host_arch = _HOST_ARCHES.get(rctx.os.arch.lower())
+    if host_os == None or host_arch == None:
+        fail("Unsupported LLVM host platform: os='{}', arch='{}'".format(
+            rctx.os.name,
+            rctx.os.arch,
+        ))
+
+    suffix = "-musl" if host_os == "linux" else ""
+    return "{}-{}{}".format(host_os, host_arch, suffix)
+
+def _release_key(index, llvm_version, requested_release):
+    if requested_release:
+        return requested_release
+
+    release = index.get("latest_by_llvm_version", {}).get(llvm_version)
+    if release == None:
+        fail("No minimal LLVM release is indexed for LLVM {}".format(llvm_version))
+    return release
+
+def _llvm_host_tools_repository_impl(rctx):
+    index = json.decode(rctx.read(rctx.path(rctx.attr.index)), default = None)
+    release = _release_key(index, rctx.attr.llvm_version, rctx.attr.release)
+    archive_target = _host_archive_target(rctx)
+    release_archives = index.get("releases", {}).get(release)
+    if release_archives == None:
+        fail("Unknown minimal LLVM release '{}'".format(release))
+
+    archive = release_archives.get(archive_target)
+    if archive == None:
+        fail("Minimal LLVM release '{}' has no archive for host '{}'".format(
+            release,
+            archive_target,
+        ))
+
+    rctx.download_and_extract(
+        url = archive["url"],
+        sha256 = archive["sha256"],
+    )
+
+    executable_suffix = ".exe" if archive_target.startswith("windows-") else ""
+    clang = "bin/clang" + executable_suffix
+    ld_lld = "bin/ld.lld" + executable_suffix
+    resource_dir = "lib/clang/{}".format(rctx.attr.llvm_version.partition(".")[0])
+
+    for tool in [clang, ld_lld]:
+        if not rctx.path(tool).exists:
+            fail("Minimal LLVM archive '{}' is missing {}".format(release, tool))
+    if not rctx.path(resource_dir).exists:
+        fail("Minimal LLVM archive '{}' is missing {}".format(release, resource_dir))
+
+    # Stable root labels let downstream repository rules use repository_ctx.path
+    # without reproducing host-specific executable suffix logic.
+    rctx.symlink(clang, "clang")
+    rctx.symlink(ld_lld, "ld.lld")
+
+    identity = {
+        "archive_sha256": archive["sha256"],
+        "host_archive_target": archive_target,
+        "llvm_version": rctx.attr.llvm_version,
+        "paths": {
+            "clang": clang,
+            "ld_lld": ld_lld,
+            "resource_dir": resource_dir,
+        },
+        "release": release,
+    }
+    rctx.file("llvm-host-tools.json", json.encode_indent(identity, indent = "  ") + "\n")
+    rctx.file("resource-dir.txt", resource_dir + "\n")
+    rctx.file(
+        "BUILD.bazel",
+        """\
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "clang",
+    "ld.lld",
+    "llvm-host-tools.json",
+    "resource-dir.txt",
+])
+
+filegroup(
+    name = "resource_dir",
+    srcs = glob([{resource_glob}], allow_empty = False),
+)
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"], allow_empty = False),
+)
+""".format(
+            resource_glob = repr(resource_dir + "/**"),
+        ),
+    )
+
+    # The selected archive depends on the repository host. Keeping this
+    # explicitly non-reproducible prevents one host's lockfile entry from being
+    # incorrectly reused for another host architecture or operating system.
+    return rctx.repo_metadata(reproducible = False)
+
+llvm_host_tools_repository = repository_rule(
+    implementation = _llvm_host_tools_repository_impl,
+    attrs = {
+        "index": attr.label(
+            allow_single_file = True,
+            default = Label(DEFAULT_LLVM_TOOLCHAIN_MINIMAL_INDEX_FILE),
+            doc = "Minimal LLVM release index.",
+        ),
+        "llvm_version": attr.string(
+            mandatory = True,
+            doc = "LLVM version whose host tools should be downloaded.",
+        ),
+        "release": attr.string(
+            doc = "Exact release key. Defaults to the index's latest release for llvm_version.",
+        ),
+    },
+    doc = "Downloads pinned clang and ld.lld tools for repository-time compiler probes.",
+)

--- a/extensions/llvm_toolchain_minimal_index.json
+++ b/extensions/llvm_toolchain_minimal_index.json
@@ -3,7 +3,7 @@
     "21.1.8": "llvm-21.1.8-10",
     "22.1.6": "llvm-22.1.6-1",
     "22.1.7": "llvm-22.1.7-2",
-    "22.1.8": "llvm-22.1.8-1"
+    "22.1.8": "llvm-22.1.8-2-adaptive"
   },
   "releases": {
     "llvm-21.1.8-10": {
@@ -134,6 +134,32 @@
       "windows-arm64": {
         "url": "https://github.com/hermeticbuild/hermetic-llvm/releases/download/llvm-22.1.8-1/llvm-toolchain-minimal-22.1.8-windows-arm64.tar.zst",
         "sha256": "b65f380f32cec910a761b5107a2fe25f8322c7e8a6561bfe40077e8360a2a647"
+      }
+    },
+    "llvm-22.1.8-2-adaptive": {
+      "darwin-amd64": {
+        "url": "https://github.com/fionera/hermetic-llvm/releases/download/llvm-22.1.8-2-adaptive/llvm-toolchain-minimal-22.1.8-darwin-amd64.tar.zst",
+        "sha256": "57049cd87d7d8b3ceea64dc65149315df2cd4d357ba35c058ed446bc86818337"
+      },
+      "darwin-arm64": {
+        "url": "https://github.com/fionera/hermetic-llvm/releases/download/llvm-22.1.8-2-adaptive/llvm-toolchain-minimal-22.1.8-darwin-arm64.tar.zst",
+        "sha256": "d477cb114def39d7e5f7ca3141ef81e19ef8685c36c0ceaf6137861e69ddae2d"
+      },
+      "linux-amd64-musl": {
+        "url": "https://github.com/fionera/hermetic-llvm/releases/download/llvm-22.1.8-2-adaptive/llvm-toolchain-minimal-22.1.8-linux-amd64-musl.tar.zst",
+        "sha256": "9451f615542fadfa2bd085951b2789a1dc79d8d7c03dbd36219645799cc89a43"
+      },
+      "linux-arm64-musl": {
+        "url": "https://github.com/fionera/hermetic-llvm/releases/download/llvm-22.1.8-2-adaptive/llvm-toolchain-minimal-22.1.8-linux-arm64-musl.tar.zst",
+        "sha256": "63eacbef4bc5015db649148592d399a946f496b742b8aa7e9b341d69328f4f84"
+      },
+      "windows-amd64": {
+        "url": "https://github.com/fionera/hermetic-llvm/releases/download/llvm-22.1.8-2-adaptive/llvm-toolchain-minimal-22.1.8-windows-amd64.tar.zst",
+        "sha256": "9ab8040892bb915c04c6016a9c4d8d9f88d7f2c8355848732fd2f058705d62fa"
+      },
+      "windows-arm64": {
+        "url": "https://github.com/fionera/hermetic-llvm/releases/download/llvm-22.1.8-2-adaptive/llvm-toolchain-minimal-22.1.8-windows-arm64.tar.zst",
+        "sha256": "ccc9ff3ca616c28fe92f352edd1e3bd6eac50421b8f79f7c197eb80d16507429"
       }
     }
   }

--- a/extensions/toolchain.bzl
+++ b/extensions/toolchain.bzl
@@ -95,6 +95,7 @@ _target_platform_tag = tag_class(
                 "riscv64",
                 "s390x",
                 "armv7",
+                "ppc64le",
                 "bpfeb",
                 "bpfel",
                 "wasm32",

--- a/host_tools_repository.bzl
+++ b/host_tools_repository.bzl
@@ -1,0 +1,5 @@
+"""Public repository-time LLVM host-tools API."""
+
+load("//extensions:llvm_host_tools_repository.bzl", _llvm_host_tools_repository = "llvm_host_tools_repository")
+
+llvm_host_tools_repository = _llvm_host_tools_repository

--- a/kernel/extension/BUILD.bazel
+++ b/kernel/extension/BUILD.bazel
@@ -32,14 +32,14 @@ bzl_library(
 )
 
 bzl_library(
-    name = "kernel_helpers",
-    srcs = ["kernel_helpers.bzl"],
-    visibility = ["//visibility:public"],
-)
-
-bzl_library(
     name = "libc_kernel_versions",
     srcs = ["libc_kernel_versions.bzl"],
     visibility = ["//visibility:public"],
     deps = ["//constraints/libc:libc_versions"],
+)
+
+bzl_library(
+    name = "kernel_helpers",
+    srcs = ["kernel_helpers.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/kernel/extension/BUILD.bazel
+++ b/kernel/extension/BUILD.bazel
@@ -41,4 +41,5 @@ bzl_library(
     name = "libc_kernel_versions",
     srcs = ["libc_kernel_versions.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//constraints/libc:libc_versions"],
 )

--- a/kernel/extension/libc_kernel_versions.bzl
+++ b/kernel/extension/libc_kernel_versions.bzl
@@ -1,5 +1,7 @@
 # Partly from https://github.com/cerisier/glibc-headers/blob/main/glibc_kernel_versions.txt
 
+load("//constraints/libc:libc_versions.bzl", "resolve_libc")
+
 LIBC_KERNEL_VERSIONS = {
     "gnu.2.17": "3.9.11",
     "gnu.2.18": "3.12.74",
@@ -32,4 +34,5 @@ LIBC_KERNEL_VERSIONS = {
     "musl": "6.16.12",  # Latest for musl always
 }
 
-LIBC_KERNEL_VERSIONS["unconstrained"] = LIBC_KERNEL_VERSIONS["gnu.2.28"]
+def libc_kernel_version(target_os, target_cpu, libc):
+    return LIBC_KERNEL_VERSIONS[resolve_libc(target_os, target_cpu, libc)]

--- a/kernel/extension/make_select_kernel_headers_repository_target.bzl
+++ b/kernel/extension/make_select_kernel_headers_repository_target.bzl
@@ -7,7 +7,7 @@ load("//constraints/kernel/linux:linux_kernel_versions.bzl", "LINUX_KERNEL_VERSI
 load("//constraints/libc:libc_versions.bzl", "LIBCS")
 load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
 load(":kernel_helpers.bzl", "arch_to_kernel_arch")
-load(":libc_kernel_versions.bzl", "LIBC_KERNEL_VERSIONS")
+load(":libc_kernel_versions.bzl", "libc_kernel_version")
 
 def _kernel_headers_repository_target(target_arch, kernel_version, bazel_target):
     return "@linux_kernel_headers_{}.{}//:{}".format(arch_to_kernel_arch(target_arch), kernel_version, bazel_target)
@@ -44,7 +44,7 @@ def _make_select_kernel_headers_repository_target_from_libc(bazel_target):
     selection = {}
     for (target_os, target_arch) in LIBC_SUPPORTED_TARGETS:
         for libc_version in LIBCS + ["unconstrained"]:
-            kernel_version = LIBC_KERNEL_VERSIONS[libc_version]
+            kernel_version = libc_kernel_version(target_os, target_arch, libc_version)
             if not _kernel_headers_available(target_arch, kernel_version):
                 continue
             apparent_target = _kernel_headers_repository_target(target_arch, kernel_version, bazel_target)

--- a/platforms/common.bzl
+++ b/platforms/common.bzl
@@ -4,7 +4,14 @@ ARCH_ALIASES = {
     "riscv64": [],
     "s390x": [],
     "armv7": [],
+    "ppc64le": [],
 }
+
+# These targets intentionally provide only a compiler, assembler, and linker.
+# They do not imply a hosted C or C++ runtime.
+FREESTANDING_TARGETS = [
+    ("linux", "ppc64le"),
+]
 
 SUPPORTED_TARGETS = [
     ("macos", "x86_64"),
@@ -14,6 +21,7 @@ SUPPORTED_TARGETS = [
     ("linux", "riscv64"),
     ("linux", "s390x"),
     ("linux", "armv7"),
+    ("linux", "ppc64le"),
     ("windows", "x86_64"),
     ("windows", "aarch64"),
     ("none", "bpfeb"),

--- a/platforms/declare_platforms.bzl
+++ b/platforms/declare_platforms.bzl
@@ -1,6 +1,6 @@
 load("//constraints/cxxstdlib:cxxstdlib_versions.bzl", "DEFAULT_CXXSTDLIB")
 load("//constraints/libc:libc_versions.bzl", "LIBCS", "default_libc")
-load("//platforms:common.bzl", "ARCH_ALIASES", "LIBC_SUPPORTED_TARGETS", "SUPPORTED_TARGETS")
+load("//platforms:common.bzl", "ARCH_ALIASES", "FREESTANDING_TARGETS", "LIBC_SUPPORTED_TARGETS", "SUPPORTED_TARGETS")
 
 def declare_platforms():
     for (target_os, target_cpu) in SUPPORTED_TARGETS:
@@ -9,10 +9,12 @@ def declare_platforms():
             "@platforms//os:{}".format(target_os),
         ]
 
-        if target_os != "none":
+        if (target_os, target_cpu) in FREESTANDING_TARGETS:
+            constraints.append("//constraints/cxxstdlib:none")
+        elif target_os != "none":
             constraints.append("//constraints/cxxstdlib:{}".format(DEFAULT_CXXSTDLIB))
 
-        if target_os == "linux":
+        if target_os == "linux" and (target_os, target_cpu) not in FREESTANDING_TARGETS:
             # We add a default glibc constraint for linux platforms.
             #
             # This is needed because some toolchains require a libc constraint

--- a/runtimes/glibc/extension/make_select_glibc_repository_target.bzl
+++ b/runtimes/glibc/extension/make_select_glibc_repository_target.bzl
@@ -1,4 +1,4 @@
-load("//constraints/libc:libc_versions.bzl", "DEFAULT_LIBC", "GLIBCS")
+load("//constraints/libc:libc_versions.bzl", "GLIBCS", "resolve_libc")
 load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
 load(":glibc.bzl", "glibc_triple")
 
@@ -7,7 +7,7 @@ def make_select_glibc_repository_target(bazel_repository, bazel_target):
     for (target_os, target_arch) in LIBC_SUPPORTED_TARGETS:
         triple = glibc_triple(target_os, target_arch)
         for libc_version in GLIBCS + ["unconstrained"]:
-            apparent_libc_value = libc_version if libc_version != "unconstrained" else DEFAULT_LIBC
+            apparent_libc_value = resolve_libc(target_os, target_arch, libc_version)
 
             # libc constraint values are "gnu.X.Y"; the glibc repos are keyed
             # by the numeric version only.

--- a/runtimes/glibc/libc_aware_target_triple.bzl
+++ b/runtimes/glibc/libc_aware_target_triple.bzl
@@ -1,4 +1,4 @@
-load("//constraints/libc:libc_versions.bzl", "DEFAULT_LIBC", "LIBCS")
+load("//constraints/libc:libc_versions.bzl", "LIBCS", "resolve_libc")
 load("//platforms:common.bzl", "LIBC_SUPPORTED_TARGETS")
 
 # Per-cpu remaps for zig target triples. Zig uses generic arch names with an
@@ -25,7 +25,7 @@ def libc_aware_target_triple():
     target = {}
     for (target_os, target_cpu) in LIBC_SUPPORTED_TARGETS:
         for libc_version in LIBCS + ["unconstrained"]:
-            target_libc_suffix = libc_version if libc_version != "unconstrained" else DEFAULT_LIBC
+            target_libc_suffix = resolve_libc(target_os, target_cpu, libc_version)
             target["//platforms/config:{}_{}_{}".format(target_os, target_cpu, libc_version)] = _zig_triple(target_os, target_cpu, target_libc_suffix)
 
     return select(target)

--- a/tests/check_linux_architecture_contracts.sh
+++ b/tests/check_linux_architecture_contracts.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly tests_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+bash "${tests_dir}/freestanding/check_ppc64le_toolchain.sh" "$@"
+bash "${tests_dir}/libc_defaults/check_unconstrained_libc_selection.sh" "$@"

--- a/tests/freestanding/BUILD.bazel
+++ b/tests/freestanding/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(":defs.bzl", "ppc64le_stage1_binary", "ppc64le_stage1_hosted_binary")
 
 package(default_visibility = ["//visibility:public"])
+
+_PPC64LE_TARGET_COMPATIBLE_WITH = [
+    "@platforms//cpu:ppc64le",
+    "@platforms//os:linux",
+]
 
 # Deliberately contains no llvm-specific libc, C++ runtime, or runtime-stage
 # constraints. CPU+OS alone must select the freestanding toolchain behavior.
@@ -15,4 +21,24 @@ platform(
 cc_library(
     name = "ppc64le_object",
     srcs = ["probe.c"],
+)
+
+ppc64le_stage1_binary(
+    name = "ppc64le_stage1_executable",
+    srcs = ["start.c"],
+    linkopts = [
+        "-Wl,--entry=_start",
+        "-Wl,--no-pie",
+    ],
+    target_compatible_with = _PPC64LE_TARGET_COMPATIBLE_WITH,
+)
+
+ppc64le_stage1_hosted_binary(
+    name = "ppc64le_stage1_hosted_executable",
+    srcs = ["start.c"],
+    linkopts = [
+        "-Wl,--entry=_start",
+        "-Wl,--no-pie",
+    ],
+    target_compatible_with = _PPC64LE_TARGET_COMPATIBLE_WITH,
 )

--- a/tests/freestanding/BUILD.bazel
+++ b/tests/freestanding/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# Deliberately contains no llvm-specific libc, C++ runtime, or runtime-stage
+# constraints. CPU+OS alone must select the freestanding toolchain behavior.
+platform(
+    name = "linux_ppc64le",
+    constraint_values = [
+        "@platforms//cpu:ppc64le",
+        "@platforms//os:linux",
+    ],
+)
+
+cc_library(
+    name = "ppc64le_object",
+    srcs = ["probe.c"],
+)

--- a/tests/freestanding/check_ppc64le_toolchain.sh
+++ b/tests/freestanding/check_ppc64le_toolchain.sh
@@ -2,11 +2,16 @@
 
 set -euo pipefail
 
-readonly target=//tests/freestanding:ppc64le_object
+readonly object_target=//tests/freestanding:ppc64le_object
+readonly executable_targets=(
+  //tests/freestanding:ppc64le_stage1_executable
+  //tests/freestanding:ppc64le_stage1_hosted_executable
+)
 readonly platform=//tests/freestanding:linux_ppc64le
 readonly bootstrap_stage=stage1_from_source
+readonly hosted_target_dependency_pattern='(^|//)(runtimes/(compiler-rt|cxxstdlib|glibc|musl)|runtimes:(crt_objects_directory|dynamic_runtime_lib|resource_directory|static_runtime_lib)|sanitizers:|toolchain:(default_libs|default_startfiles|resource_dir|rtlib))|@(glibc|kernel_headers|llvm-project|musl)//'
 
-command_args=()
+command_args=(--noannounce_rc)
 if [[ -n "${BAZEL_REMOTE_HEADER:-}" ]]; then
   command_args+=("--remote_header=${BAZEL_REMOTE_HEADER}")
 fi
@@ -15,10 +20,11 @@ bazel "$@" build "${command_args[@]}" \
   --platforms="${platform}" \
   --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
   --remote_download_outputs=toplevel \
-  "${target}"
+  "${object_target}" \
+  "${executable_targets[@]}"
 
 target_line=$(
-  bazel "$@" cquery "${target}" \
+  bazel "$@" cquery "${object_target}" \
     "${command_args[@]}" \
     --platforms="${platform}" \
     --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
@@ -28,13 +34,13 @@ target_config=${target_line##* (}
 target_config=${target_config%)}
 
 bad_target_runtime_deps=$(
-  bazel "$@" cquery "deps(${target})" \
+  bazel "$@" cquery "deps(${object_target})" \
     "${command_args[@]}" \
     --platforms="${platform}" \
     --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
     --output=label |
     awk -v config="(${target_config})" '$NF == config' |
-    grep -E '(@llvm//runtimes/(cxxstdlib|glibc|musl)|@llvm-project//(compiler-rt|libcxx|libcxxabi)|@glibc|@musl)' || true
+    grep -E "${hosted_target_dependency_pattern}" || true
 )
 
 if [[ -n "${bad_target_runtime_deps}" ]]; then
@@ -43,7 +49,7 @@ if [[ -n "${bad_target_runtime_deps}" ]]; then
   exit 1
 fi
 
-compile_actions=$(bazel "$@" aquery "mnemonic(CppCompile, ${target})" \
+compile_actions=$(bazel "$@" aquery "mnemonic(CppCompile, ${object_target})" \
   "${command_args[@]}" \
   --platforms="${platform}" \
   --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}")
@@ -52,7 +58,7 @@ if ! grep -q -- 'powerpc64le-linux-gnu' <<<"${compile_actions}"; then
   exit 1
 fi
 
-archive=$(bazel "$@" cquery "${target}" \
+archive=$(bazel "$@" cquery "${object_target}" \
   "${command_args[@]}" \
   --platforms="${platform}" \
   --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
@@ -63,3 +69,112 @@ grep -q 'Class:.*ELF64' <<<"${elf_header}"
 grep -q "Data:.*little endian" <<<"${elf_header}"
 grep -q 'Type:.*REL' <<<"${elf_header}"
 grep -q 'Machine:.*PowerPC64' <<<"${elf_header}"
+
+for target in "${executable_targets[@]}"; do
+  target_name=${target##*:}
+  action_commands=$(
+    bazel "$@" aquery "mnemonic('CppCompile|CppLink', deps(${target}))" \
+      "${command_args[@]}" \
+      --color=no \
+      --platforms="${platform}" \
+      --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
+      --output=commands |
+      grep -F "${target_name}_/${target_name}" || true
+  )
+  if [[ -z "${action_commands}" ]]; then
+    echo "Could not locate compile and link actions for ${target}" >&2
+    exit 1
+  fi
+
+  for required in \
+    powerpc64le-linux-gnu \
+    -fuse-ld=lld \
+    -nostdlib \
+    -static \
+    --entry=_start \
+    --no-pie; do
+    if ! grep -Fq -- "${required}" <<<"${action_commands}"; then
+      echo "${target} is missing required freestanding link argument ${required}" >&2
+      exit 1
+    fi
+  done
+
+  dependency_lines=$(
+    bazel "$@" cquery "deps(${target})" \
+      "${command_args[@]}" \
+      --platforms="${platform}" \
+      --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
+      --output=label
+  )
+  internal_target_line=$(
+    grep -F "//tests/freestanding:${target_name}_/${target_name} " <<<"${dependency_lines}" |
+      head -n 1 || true
+  )
+  if [[ -z "${internal_target_line}" ]]; then
+    echo "Could not locate transitioned target configuration for ${target}" >&2
+    exit 1
+  fi
+  internal_target_config=${internal_target_line##* (}
+  internal_target_config=${internal_target_config%)}
+  bad_target_runtime_deps=$(
+    awk -v config="(${internal_target_config})" '$NF == config' <<<"${dependency_lines}" |
+      grep -E "${hosted_target_dependency_pattern}" || true
+  )
+  if [[ -n "${bad_target_runtime_deps}" ]]; then
+    echo "${target} selected hosted target dependencies:" >&2
+    echo "${bad_target_runtime_deps}" >&2
+    exit 1
+  fi
+
+  for forbidden in \
+    ' -B' \
+    -resource-dir \
+    -rtlib=compiler-rt \
+    libclang_rt \
+    crtbegin \
+    crtend \
+    kernel_headers \
+    sanitizers_headers \
+    runtimes/cxxstdlib \
+    runtimes/glibc \
+    runtimes/musl \
+    -lpthread \
+    -ldl \
+    -lstdc++ \
+    -lc++ \
+    -lc; do
+    if grep -Fq -- "${forbidden}" <<<"${action_commands}"; then
+      echo "${target} unexpectedly uses hosted argument or input ${forbidden}" >&2
+      exit 1
+    fi
+  done
+
+  binary=$(
+    bazel "$@" cquery "${target}" \
+      "${command_args[@]}" \
+      --platforms="${platform}" \
+      --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
+      --output=files |
+      awk -v target_name="${target_name}" '$0 ~ ("/" target_name "$") { print; exit }'
+  )
+  if [[ -z "${binary}" ]]; then
+    echo "Could not locate linked output for ${target}" >&2
+    exit 1
+  fi
+
+  elf_header=$(readelf -h "${binary}")
+  grep -q 'Class:.*ELF64' <<<"${elf_header}"
+  grep -q "Data:.*little endian" <<<"${elf_header}"
+  grep -q 'Type:.*EXEC' <<<"${elf_header}"
+  grep -q 'Machine:.*PowerPC64' <<<"${elf_header}"
+  if readelf -l "${binary}" | grep -q 'INTERP'; then
+    echo "${target} unexpectedly requests a hosted program interpreter" >&2
+    exit 1
+  fi
+  if readelf -d "${binary}" 2>/dev/null | grep -q 'NEEDED'; then
+    echo "${target} unexpectedly depends on a shared library" >&2
+    exit 1
+  fi
+  readelf -p .comment "${binary}" | grep -q 'Linker: LLD'
+  readelf -Ws "${binary}" | grep -q '[[:space:]]_start$'
+done

--- a/tests/freestanding/check_ppc64le_toolchain.sh
+++ b/tests/freestanding/check_ppc64le_toolchain.sh
@@ -73,13 +73,15 @@ grep -q 'Machine:.*PowerPC64' <<<"${elf_header}"
 for target in "${executable_targets[@]}"; do
   target_name=${target##*:}
   action_commands=$(
-    bazel "$@" aquery "mnemonic('CppCompile|CppLink', deps(${target}))" \
+    bazel "$@" aquery \
+      "outputs('.*${target_name}_/${target_name}(/.*)?', mnemonic('CppCompile|CppLink', deps(${target})))" \
       "${command_args[@]}" \
       --color=no \
+      --include_commandline \
+      --noinclude_artifacts \
       --platforms="${platform}" \
       --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
-      --output=commands |
-      grep -F "${target_name}_/${target_name}" || true
+      --output=text
   )
   if [[ -z "${action_commands}" ]]; then
     echo "Could not locate compile and link actions for ${target}" >&2

--- a/tests/freestanding/check_ppc64le_toolchain.sh
+++ b/tests/freestanding/check_ppc64le_toolchain.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly target=//tests/freestanding:ppc64le_object
+readonly platform=//tests/freestanding:linux_ppc64le
+readonly bootstrap_stage=stage1_from_source
+
+command_args=()
+if [[ -n "${BAZEL_REMOTE_HEADER:-}" ]]; then
+  command_args+=("--remote_header=${BAZEL_REMOTE_HEADER}")
+fi
+
+bazel "$@" build "${command_args[@]}" \
+  --platforms="${platform}" \
+  --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
+  --remote_download_outputs=toplevel \
+  "${target}"
+
+target_line=$(
+  bazel "$@" cquery "${target}" \
+    "${command_args[@]}" \
+    --platforms="${platform}" \
+    --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
+    --output=label
+)
+target_config=${target_line##* (}
+target_config=${target_config%)}
+
+bad_target_runtime_deps=$(
+  bazel "$@" cquery "deps(${target})" \
+    "${command_args[@]}" \
+    --platforms="${platform}" \
+    --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
+    --output=label |
+    awk -v config="(${target_config})" '$NF == config' |
+    grep -E '(@llvm//runtimes/(cxxstdlib|glibc|musl)|@llvm-project//(compiler-rt|libcxx|libcxxabi)|@glibc|@musl)' || true
+)
+
+if [[ -n "${bad_target_runtime_deps}" ]]; then
+  echo "linux+ppc64le selected hosted target runtimes:" >&2
+  echo "${bad_target_runtime_deps}" >&2
+  exit 1
+fi
+
+compile_actions=$(bazel "$@" aquery "mnemonic(CppCompile, ${target})" \
+  "${command_args[@]}" \
+  --platforms="${platform}" \
+  --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}")
+if ! grep -q -- 'powerpc64le-linux-gnu' <<<"${compile_actions}"; then
+  echo "linux+ppc64le did not select the powerpc64le-linux-gnu compiler triple" >&2
+  exit 1
+fi
+
+archive=$(bazel "$@" cquery "${target}" \
+  "${command_args[@]}" \
+  --platforms="${platform}" \
+  --@llvm//toolchain:bootstrap_stage="${bootstrap_stage}" \
+  --output=files | grep -E '\.a$' | head -n 1)
+elf_header=$(readelf -h "${archive}")
+
+grep -q 'Class:.*ELF64' <<<"${elf_header}"
+grep -q "Data:.*little endian" <<<"${elf_header}"
+grep -q 'Type:.*REL' <<<"${elf_header}"
+grep -q 'Machine:.*PowerPC64' <<<"${elf_header}"

--- a/tests/freestanding/defs.bzl
+++ b/tests/freestanding/defs.bzl
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@with_cfg.bzl", "with_cfg")
+load("//toolchain/runtimes:with_cfg_runtimes_common.bzl", "configure_builder_for_runtimes")
+
+ppc64le_stage1_binary, _ppc64le_stage1_binary_internal = configure_builder_for_runtimes(
+    with_cfg(cc_binary),
+    "stage1",
+).build()
+
+ppc64le_stage1_hosted_binary, _ppc64le_stage1_hosted_binary_internal = configure_builder_for_runtimes(
+    with_cfg(cc_binary),
+    "stage1_hosted",
+).build()

--- a/tests/freestanding/probe.c
+++ b/tests/freestanding/probe.c
@@ -1,0 +1,3 @@
+unsigned long hermetic_llvm_ppc64le_probe(unsigned long value) {
+    return value + 1;
+}

--- a/tests/freestanding/start.c
+++ b/tests/freestanding/start.c
@@ -1,0 +1,5 @@
+__attribute__((noreturn)) void _start(void) {
+    for (;;) {
+        __asm__ volatile("" ::: "memory");
+    }
+}

--- a/tests/host_tools/BUILD.bazel
+++ b/tests/host_tools/BUILD.bazel
@@ -1,0 +1,5 @@
+load(":host_tools_paths_test.bzl", "host_tools_paths_test")
+
+host_tools_paths_test(
+    name = "host_tools_paths_test",
+)

--- a/tests/host_tools/host_tools_paths_test.bzl
+++ b/tests/host_tools/host_tools_paths_test.bzl
@@ -1,10 +1,23 @@
 """Tests for portable repository-time LLVM executable paths."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//extensions:llvm_host_tools_paths.bzl", "llvm_host_tools_layout")
+load(
+    "//extensions:llvm_host_tools_paths.bzl",
+    "llvm_host_tools_archive_target",
+    "llvm_host_tools_layout",
+)
 
 def _host_tools_paths_test_impl(ctx):
     env = unittest.begin(ctx)
+
+    for os_name, arch, want in [
+        ("Linux", "amd64", "linux-amd64-musl"),
+        ("Mac OS X", "x86_64", "darwin-amd64"),
+        ("macOS", "arm64", "darwin-arm64"),
+        ("Windows Server 2025", "amd64", "windows-amd64"),
+        ("Windows 11", "aarch64", "windows-arm64"),
+    ]:
+        asserts.equals(env, want, llvm_host_tools_archive_target(os_name, arch))
 
     windows = llvm_host_tools_layout("windows-amd64")
     asserts.equals(env, "bin/clang.exe", windows.archive_paths["clang"])

--- a/tests/host_tools/host_tools_paths_test.bzl
+++ b/tests/host_tools/host_tools_paths_test.bzl
@@ -1,0 +1,35 @@
+"""Tests for portable repository-time LLVM executable paths."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//extensions:llvm_host_tools_paths.bzl", "llvm_host_tools_layout")
+
+def _host_tools_paths_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    windows = llvm_host_tools_layout("windows-amd64")
+    asserts.equals(env, "bin/clang.exe", windows.archive_paths["clang"])
+    asserts.equals(env, "bin/ld.lld.exe", windows.archive_paths["ld_lld"])
+    asserts.equals(env, "clang", windows.compatibility_paths["clang"])
+    asserts.equals(env, "ld.lld", windows.compatibility_paths["ld_lld"])
+    asserts.equals(env, "clang.exe", windows.probe_paths["clang"])
+    asserts.equals(env, "ld.lld.exe", windows.probe_paths["ld_lld"])
+    asserts.equals(env, "bin/clang.exe", windows.root_symlinks["clang"])
+    asserts.equals(env, "bin/clang.exe", windows.root_symlinks["clang.exe"])
+    asserts.equals(env, "bin/ld.lld.exe", windows.root_symlinks["ld.lld"])
+    asserts.equals(env, "bin/ld.lld.exe", windows.root_symlinks["ld.lld.exe"])
+
+    linux = llvm_host_tools_layout("linux-amd64-musl")
+    asserts.equals(env, "bin/clang", linux.archive_paths["clang"])
+    asserts.equals(env, "bin/ld.lld", linux.archive_paths["ld_lld"])
+    asserts.equals(env, "bin/clang", linux.root_symlinks["clang"])
+    asserts.equals(env, "bin/clang", linux.root_symlinks["clang.exe"])
+    asserts.equals(env, "bin/ld.lld", linux.root_symlinks["ld.lld"])
+    asserts.equals(env, "bin/ld.lld", linux.root_symlinks["ld.lld.exe"])
+
+    darwin = llvm_host_tools_layout("darwin-arm64")
+    asserts.equals(env, "bin/clang", darwin.root_symlinks["clang.exe"])
+    asserts.equals(env, "bin/ld.lld", darwin.root_symlinks["ld.lld.exe"])
+
+    return unittest.end(env)
+
+host_tools_paths_test = unittest.make(_host_tools_paths_test_impl)

--- a/tests/libc_defaults/BUILD.bazel
+++ b/tests/libc_defaults/BUILD.bazel
@@ -1,0 +1,21 @@
+load(":libc_defaults_test.bzl", "architecture_aware_default_libc_test")
+
+platform(
+    name = "linux_riscv64_unconstrained",
+    constraint_values = [
+        "@platforms//cpu:riscv64",
+        "@platforms//os:linux",
+    ],
+)
+
+platform(
+    name = "linux_x86_64_unconstrained",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)
+
+architecture_aware_default_libc_test(
+    name = "architecture_aware_default_libc_test",
+)

--- a/tests/libc_defaults/check_unconstrained_libc_selection.sh
+++ b/tests/libc_defaults/check_unconstrained_libc_selection.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly runtime_target=//runtimes/compiler-rt:clang_rt.builtins.static
+readonly riscv_platform=//tests/libc_defaults:linux_riscv64_unconstrained
+readonly x86_platform=//tests/libc_defaults:linux_x86_64_unconstrained
+
+command_args=(--noannounce_rc)
+if [[ -n "${BAZEL_REMOTE_HEADER:-}" ]]; then
+  command_args+=("--remote_header=${BAZEL_REMOTE_HEADER}")
+fi
+
+bazel "$@" build "${command_args[@]}" \
+  --platforms="${riscv_platform}" \
+  --remote_download_outputs=toplevel \
+  "${runtime_target}"
+
+verify_selection() {
+  local platform=$1
+  local required_glibc=$2
+  local required_kernel=$3
+  local forbidden_glibc=$4
+  local forbidden_kernel=$5
+  local dependencies
+  shift 5
+
+  dependencies=$(
+    bazel "$@" cquery "deps(${runtime_target})" \
+      "${command_args[@]}" \
+      --platforms="${platform}" \
+      --output=label
+  )
+
+  for required in "${required_glibc}" "${required_kernel}"; do
+    if ! grep -Fq -- "${required}" <<<"${dependencies}"; then
+      echo "${platform} did not select required dependency ${required}" >&2
+      exit 1
+    fi
+  done
+
+  for forbidden in "${forbidden_glibc}" "${forbidden_kernel}"; do
+    if grep -Fq -- "${forbidden}" <<<"${dependencies}"; then
+      echo "${platform} unexpectedly selected dependency ${forbidden}" >&2
+      exit 1
+    fi
+  done
+}
+
+verify_selection \
+  "${riscv_platform}" \
+  "glibc_headers_riscv64-linux-gnu.2.33//:gnu_libc_headers" \
+  "linux_kernel_headers_riscv.5.12.19//:kernel_headers" \
+  "glibc_headers_riscv64-linux-gnu.2.28" \
+  "linux_kernel_headers_riscv.4.19.325" \
+  "$@"
+
+verify_selection \
+  "${x86_platform}" \
+  "glibc_headers_x86_64-linux-gnu.2.28//:gnu_libc_headers" \
+  "linux_kernel_headers_x86.4.19.325//:kernel_headers" \
+  "glibc_headers_x86_64-linux-gnu.2.33" \
+  "linux_kernel_headers_x86.5.12.19" \
+  "$@"

--- a/tests/libc_defaults/libc_defaults_test.bzl
+++ b/tests/libc_defaults/libc_defaults_test.bzl
@@ -1,0 +1,66 @@
+"""Tests for architecture-aware libc defaults."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//3rd_party/libc/glibc:helpers.bzl", "glibc_version_config_settings")
+load("//constraints/libc:libc_versions.bzl", "resolve_libc")
+load("//kernel/extension:libc_kernel_versions.bzl", "libc_kernel_version")
+
+_ORDINARY_LINUX_CPUS = [
+    "x86_64",
+    "aarch64",
+    "s390x",
+    "armv7",
+]
+
+def _architecture_aware_default_libc_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        "gnu.2.33",
+        resolve_libc("linux", "riscv64", "unconstrained"),
+    )
+    asserts.equals(
+        env,
+        "5.12.19",
+        libc_kernel_version("linux", "riscv64", "unconstrained"),
+    )
+
+    for target_cpu in _ORDINARY_LINUX_CPUS:
+        asserts.equals(
+            env,
+            "gnu.2.28",
+            resolve_libc("linux", target_cpu, "unconstrained"),
+        )
+        asserts.equals(
+            env,
+            "4.19.325",
+            libc_kernel_version("linux", target_cpu, "unconstrained"),
+        )
+
+    # Explicit constraints must not be remapped, even on RISC-V.
+    asserts.equals(env, "gnu.2.28", resolve_libc("linux", "riscv64", "gnu.2.28"))
+    asserts.equals(env, "musl", resolve_libc("linux", "riscv64", "musl"))
+
+    glibc_2_28_to_2_32 = glibc_version_config_settings([
+        "gnu.2.28",
+        "gnu.2.29",
+        "gnu.2.30",
+        "gnu.2.31",
+        "gnu.2.32",
+    ])
+    glibc_2_33 = glibc_version_config_settings(["gnu.2.33"])
+    riscv_unconstrained = "@llvm//platforms/config:linux_riscv64_unconstrained"
+
+    asserts.equals(env, False, riscv_unconstrained in glibc_2_28_to_2_32)
+    asserts.equals(env, True, riscv_unconstrained in glibc_2_33)
+    for target_cpu in _ORDINARY_LINUX_CPUS:
+        unconstrained = "@llvm//platforms/config:linux_{}_unconstrained".format(target_cpu)
+        asserts.equals(env, True, unconstrained in glibc_2_28_to_2_32)
+        asserts.equals(env, False, unconstrained in glibc_2_33)
+
+    return unittest.end(env)
+
+architecture_aware_default_libc_test = unittest.make(
+    _architecture_aware_default_libc_test_impl,
+)

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -6,6 +6,7 @@ load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_args_list")
 load("//toolchain/bootstrap:declare_toolchains.bzl", declare_bootstrap_toolchains = "declare_toolchains")
 load(":bootstrap_stages.bzl", "BOOTSTRAP_STAGES")
 load(":declare_toolchains.bzl", "declare_toolchains")
+load(":freestanding.bzl", "PPC64LE_FREESTANDING_RUNTIME_STAGES")
 
 package(default_visibility = ["//toolchain:__subpackages__"])
 
@@ -104,12 +105,7 @@ config_setting(
         },
         visibility = ["//visibility:public"],
     )
-    for runtime_stage in [
-        "stage0",
-        "stage1",
-        "stage1_hosted",
-        "complete",
-    ]
+    for runtime_stage in PPC64LE_FREESTANDING_RUNTIME_STAGES
 ]
 
 config_setting(
@@ -458,8 +454,14 @@ bzl_library(
     name = "cc_toolchain",
     srcs = ["cc_toolchain.bzl"],
     deps = [
+        ":freestanding",
         "@rules_cc//cc/toolchains:toolchain_rules",
     ],
+)
+
+bzl_library(
+    name = "freestanding",
+    srcs = ["freestanding.bzl"],
 )
 
 bzl_library(

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -460,11 +460,6 @@ bzl_library(
 )
 
 bzl_library(
-    name = "freestanding",
-    srcs = ["freestanding.bzl"],
-)
-
-bzl_library(
     name = "declare_toolchains",
     srcs = ["declare_toolchains.bzl"],
     deps = [
@@ -485,4 +480,9 @@ bzl_library(
     name = "bootstrap_stages",
     srcs = ["bootstrap_stages.bzl"],
     visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "freestanding",
+    srcs = ["freestanding.bzl"],
 )

--- a/toolchain/BUILD.bazel
+++ b/toolchain/BUILD.bazel
@@ -89,6 +89,29 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# ppc64le currently provides a freestanding toolchain only. These settings are
+# deliberately more specific than the general runtime-stage settings, so a
+# custom platform containing only linux+ppc64le cannot select hosted inputs.
+[
+    config_setting(
+        name = "linux_ppc64le_freestanding_{}".format(runtime_stage),
+        constraint_values = [
+            "@platforms//cpu:ppc64le",
+            "@platforms//os:linux",
+        ],
+        flag_values = {
+            ":runtime_stage": runtime_stage,
+        },
+        visibility = ["//visibility:public"],
+    )
+    for runtime_stage in [
+        "stage0",
+        "stage1",
+        "stage1_hosted",
+        "complete",
+    ]
+]
+
 config_setting(
     name = "linux_complete",
     constraint_values = [

--- a/toolchain/args/llvm_target_triple.bzl
+++ b/toolchain/args/llvm_target_triple.bzl
@@ -5,6 +5,9 @@ LLVM_TARGET_TRIPLE = select({
     "@llvm//platforms/config:linux_riscv64_gnu": ["riscv64-linux-gnu"],
     "@llvm//platforms/config:linux_s390x_gnu": ["s390x-linux-gnu"],
     "@llvm//platforms/config:linux_armv7_gnu": ["armv7-linux-gnueabihf"],
+    # The ppc64le target is freestanding. Its unconstrained libc setting is
+    # matched explicitly so the triple does not imply hosted runtime support.
+    "@llvm//platforms/config:linux_ppc64le": ["powerpc64le-linux-gnu"],
     "@llvm//platforms/config:linux_x86_64_musl": ["x86_64-linux-musl"],
     "@llvm//platforms/config:linux_aarch64_musl": ["aarch64-linux-musl"],
     "@llvm//platforms/config:linux_riscv64_musl": ["riscv64-linux-musl"],

--- a/toolchain/bootstrap/declare_toolchains.bzl
+++ b/toolchain/bootstrap/declare_toolchains.bzl
@@ -418,6 +418,7 @@ def declare_toolchains(*, execs = None, targets = SUPPORTED_TARGETS):
             cc_toolchain(
                 name = cc_toolchain_name,
                 tool_map = select({
+                    "@llvm//toolchain:linux_ppc64le_freestanding_complete": ":%s/staged_default_tools" % tool_prefix,
                     "@llvm//toolchain:linux_complete": ":%s/tools_with_interface_libraries" % tool_prefix,
                     "@llvm//toolchain:macos_complete_with_libtool": ":%s/tools_with_dsym_and_libtool" % tool_prefix,
                     "@llvm//toolchain:macos_complete": ":%s/tools_with_dsym" % tool_prefix,

--- a/toolchain/bootstrap/stage3/BUILD.bazel
+++ b/toolchain/bootstrap/stage3/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//platforms:common.bzl", "SUPPORTED_TARGETS")
+load("//platforms:common.bzl", "FREESTANDING_TARGETS", "SUPPORTED_TARGETS")
 load("//toolchain/bootstrap:bootstrap_binary.bzl", "bootstrap_binaries")
 load("//toolchain/bootstrap:fdo_profile.bzl", "llvm_fdo_profile_data", "llvm_fdo_profile_workload")
 
@@ -18,7 +18,7 @@ bootstrap_binaries(fdo_profile = ":llvm_fdo_profdata")
 [
     llvm_fdo_profile_workload(
         name = "llvm_fdo_profile_workload_%s_to_%s_%s" % (executor, target_os, target_cpu),
-        srcs = ":fdo_freestanding.c" if target_os == "none" else "@llvm_fdo_zstd//:zstd_compress_files",
+        srcs = ":fdo_freestanding.c" if target_os == "none" or (target_os, target_cpu) in FREESTANDING_TARGETS else "@llvm_fdo_zstd//:zstd_compress_files",
         exec_compatible_with = [
             "@platforms//cpu:" + executor_config["cpu"],
             "@platforms//os:linux",
@@ -27,7 +27,7 @@ bootstrap_binaries(fdo_profile = ":llvm_fdo_profdata")
             "Arch": executor_config["buildbuddy_arch"],
         },
         target_platform = "//platforms:%s_%s" % (target_os, target_cpu),
-        workload_kind = "freestanding" if target_os == "none" else "hosted",
+        workload_kind = "freestanding" if target_os == "none" or (target_os, target_cpu) in FREESTANDING_TARGETS else "hosted",
     )
     for executor, executor_config in _LLVM_FDO_EXECUTORS.items()
     for target_os, target_cpu in SUPPORTED_TARGETS

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -1,13 +1,6 @@
 load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load("@rules_cc//cc/toolchains:toolchain.bzl", _cc_toolchain = "cc_toolchain")
-
-_FREESTANDING_PPC64LE_SETTINGS = [
-    "@llvm//toolchain:linux_ppc64le_freestanding_{}".format(runtime_stage)
-    for runtime_stage in ["stage0", "stage1", "stage1_hosted", "complete"]
-]
-
-def _freestanding_ppc64le_select(value):
-    return {setting: value for setting in _FREESTANDING_PPC64LE_SETTINGS}
+load("//toolchain:freestanding.bzl", "ppc64le_freestanding_select")
 
 def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
     cc_feature_set(
@@ -101,7 +94,7 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
 
     _cc_toolchain(
         name = name,
-        args = select(_freestanding_ppc64le_select(["@llvm//toolchain/runtimes:toolchain_args"]) | {
+        args = select(ppc64le_freestanding_select(["@llvm//toolchain/runtimes:toolchain_args"]) | {
             "@llvm//toolchain:runtimes_none": ["@llvm//toolchain/runtimes:toolchain_args"],
             "@llvm//toolchain:runtimes_stage1": ["@llvm//toolchain/runtimes:toolchain_args"],
             "@llvm//toolchain:runtimes_stage1_hosted": ["@llvm//toolchain/runtimes:toolchain_args"],
@@ -122,7 +115,7 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             ],
             "//conditions:default": [],
         }),
-        known_features = select(_freestanding_ppc64le_select([
+        known_features = select(ppc64le_freestanding_select([
             "@llvm//toolchain/features:external_include_paths",
             "@llvm//toolchain/features:fdo_optimize",
         ]) | {
@@ -140,7 +133,7 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             ],
             "//conditions:default": [name + "_known_features"],
         }),
-        enabled_features = select(_freestanding_ppc64le_select([name + "_runtimes_only_enabled_features"]) | {
+        enabled_features = select(ppc64le_freestanding_select([name + "_runtimes_only_enabled_features"]) | {
             "@llvm//toolchain:runtimes_none": [name + "_runtimes_only_enabled_features"],
             "@llvm//toolchain:runtimes_stage1": [name + "_runtimes_only_enabled_features"],
             "@llvm//toolchain:runtimes_stage1_hosted": [name + "_runtimes_only_enabled_features"],
@@ -148,13 +141,13 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
         }),
         tool_map = tool_map,
         module_map = module_map,
-        static_runtime_lib = select(_freestanding_ppc64le_select("@llvm//runtimes:none") | {
+        static_runtime_lib = select(ppc64le_freestanding_select("@llvm//runtimes:none") | {
             "@llvm//toolchain:runtimes_none": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1_hosted": "@llvm//runtimes:none",
             "//conditions:default": "@llvm//runtimes:static_runtime_lib",
         }),
-        dynamic_runtime_lib = select(_freestanding_ppc64le_select("@llvm//runtimes:none") | {
+        dynamic_runtime_lib = select(ppc64le_freestanding_select("@llvm//runtimes:none") | {
             "@llvm//toolchain:runtimes_none": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1_hosted": "@llvm//runtimes:none",

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -1,6 +1,14 @@
 load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load("@rules_cc//cc/toolchains:toolchain.bzl", _cc_toolchain = "cc_toolchain")
 
+_FREESTANDING_PPC64LE_SETTINGS = [
+    "@llvm//toolchain:linux_ppc64le_freestanding_{}".format(runtime_stage)
+    for runtime_stage in ["stage0", "stage1", "stage1_hosted", "complete"]
+]
+
+def _freestanding_ppc64le_select(value):
+    return {setting: value for setting in _FREESTANDING_PPC64LE_SETTINGS}
+
 def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
     cc_feature_set(
         name = name + "_known_features",
@@ -93,7 +101,7 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
 
     _cc_toolchain(
         name = name,
-        args = select({
+        args = select(_freestanding_ppc64le_select(["@llvm//toolchain/runtimes:toolchain_args"]) | {
             "@llvm//toolchain:runtimes_none": ["@llvm//toolchain/runtimes:toolchain_args"],
             "@llvm//toolchain:runtimes_stage1": ["@llvm//toolchain/runtimes:toolchain_args"],
             "@llvm//toolchain:runtimes_stage1_hosted": ["@llvm//toolchain/runtimes:toolchain_args"],
@@ -114,7 +122,10 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             ],
             "//conditions:default": [],
         }),
-        known_features = select({
+        known_features = select(_freestanding_ppc64le_select([
+            "@llvm//toolchain/features:external_include_paths",
+            "@llvm//toolchain/features:fdo_optimize",
+        ]) | {
             "@llvm//toolchain:runtimes_none": [
                 "@llvm//toolchain/features:external_include_paths",
                 "@llvm//toolchain/features:fdo_optimize",
@@ -129,7 +140,7 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
             ],
             "//conditions:default": [name + "_known_features"],
         }),
-        enabled_features = select({
+        enabled_features = select(_freestanding_ppc64le_select([name + "_runtimes_only_enabled_features"]) | {
             "@llvm//toolchain:runtimes_none": [name + "_runtimes_only_enabled_features"],
             "@llvm//toolchain:runtimes_stage1": [name + "_runtimes_only_enabled_features"],
             "@llvm//toolchain:runtimes_stage1_hosted": [name + "_runtimes_only_enabled_features"],
@@ -137,13 +148,13 @@ def cc_toolchain(name, tool_map, module_map = None, extra_args = []):
         }),
         tool_map = tool_map,
         module_map = module_map,
-        static_runtime_lib = select({
+        static_runtime_lib = select(_freestanding_ppc64le_select("@llvm//runtimes:none") | {
             "@llvm//toolchain:runtimes_none": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1_hosted": "@llvm//runtimes:none",
             "//conditions:default": "@llvm//runtimes:static_runtime_lib",
         }),
-        dynamic_runtime_lib = select({
+        dynamic_runtime_lib = select(_freestanding_ppc64le_select("@llvm//runtimes:none") | {
             "@llvm//toolchain:runtimes_none": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1": "@llvm//runtimes:none",
             "@llvm//toolchain:runtimes_stage1_hosted": "@llvm//runtimes:none",

--- a/toolchain/freestanding.bzl
+++ b/toolchain/freestanding.bzl
@@ -1,0 +1,25 @@
+PPC64LE_FREESTANDING_RUNTIME_STAGES = [
+    "stage0",
+    "stage1",
+    "stage1_hosted",
+    "complete",
+]
+
+_PPC64LE_FREESTANDING_RUNTIME_SETTINGS = [
+    "@llvm//toolchain:linux_ppc64le_freestanding_{}".format(runtime_stage)
+    for runtime_stage in PPC64LE_FREESTANDING_RUNTIME_STAGES
+]
+
+def ppc64le_freestanding_select(value):
+    """Returns a select map covering every freestanding ppc64le runtime stage.
+
+    Args:
+        value: The select value to use for every runtime stage.
+
+    Returns:
+        A dictionary keyed by the stage-specific ppc64le config settings.
+    """
+    return {
+        setting: value
+        for setting in _PPC64LE_FREESTANDING_RUNTIME_SETTINGS
+    }

--- a/toolchain/llvm/llvm.bzl
+++ b/toolchain/llvm/llvm.bzl
@@ -358,6 +358,13 @@ def declare_llvm_targets(*, suffix = ""):
         }),
     )
 
+    include_path(
+        name = "freestanding_target_headers",
+        srcs = [
+            ":builtin_resource_dir",
+        ],
+    )
+
     # this must match //toolchain:windows_toolchain_args
     include_path(
         name = "windows_target_headers",
@@ -393,5 +400,11 @@ def declare_llvm_targets(*, suffix = ""):
             "@platforms//os:windows": ":windows_target_headers",
             "@platforms//os:none": ":wasm_target_headers",
         }),
+        visibility = ["//visibility:public"],
+    )
+
+    module_map(
+        name = "freestanding_module_map",
+        include_path = ":freestanding_target_headers",
         visibility = ["//visibility:public"],
     )

--- a/toolchain/runtimes/BUILD.bazel
+++ b/toolchain/runtimes/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_args_list")
+load("//toolchain:freestanding.bzl", "ppc64le_freestanding_select")
 
 # gazelle:exclude cc_unsanitized_library.bzl
 
@@ -88,7 +89,7 @@ cc_args_list(
 
 cc_args_list(
     name = "staged_platform_specific_args",
-    args = select({
+    args = select(ppc64le_freestanding_select([]) | {
         "//toolchain:runtimes_stage1_hosted": [
             ":stage1_hosted_platform_specific_args",
         ],
@@ -150,7 +151,7 @@ cc_args_list(
 
 cc_args_list(
     name = "resource_dir",
-    args = select({
+    args = select(ppc64le_freestanding_select([]) | {
         "//toolchain:runtimes_all": [],
         "//toolchain:runtimes_stage1": ["//toolchain:resource_dir"],
         "//toolchain:runtimes_stage1_hosted": ["//toolchain:resource_dir"],
@@ -160,7 +161,7 @@ cc_args_list(
 
 cc_args_list(
     name = "default_startfiles",
-    args = select({
+    args = select(ppc64le_freestanding_select([]) | {
         "//toolchain:runtimes_all": [],
         "//toolchain:runtimes_stage1": ["//toolchain:default_startfiles"],
         "//toolchain:runtimes_stage1_hosted": ["//toolchain:default_startfiles"],
@@ -170,7 +171,7 @@ cc_args_list(
 
 cc_args_list(
     name = "rtlib",
-    args = select({
+    args = select(ppc64le_freestanding_select([]) | {
         "//toolchain:runtimes_all": [],
         "//toolchain:runtimes_stage1": [
             "//toolchain:rtlib",
@@ -185,7 +186,7 @@ cc_args_list(
 #TODO(cerisier): Need a level of indirection to handle OS differences between stages.
 cc_args_list(
     name = "default_libs",
-    args = select({
+    args = select(ppc64le_freestanding_select([]) | {
         "//toolchain:runtimes_all": [],
         "//toolchain:runtimes_stage1": [
             "//toolchain:default_libs",

--- a/toolchain/runtimes/args/BUILD.bazel
+++ b/toolchain/runtimes/args/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains/impl:documented_api.bzl", "cc_args_list")
+load("//toolchain:freestanding.bzl", "ppc64le_freestanding_select")
 
 package(default_visibility = ["//toolchain/runtimes:__subpackages__"])
 
@@ -204,19 +205,10 @@ cc_args(
     actions = [
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
-    args = select({
-        "//toolchain:linux_ppc64le_freestanding_stage0": [
-            "-nostdlib",
-        ],
-        "//toolchain:linux_ppc64le_freestanding_stage1": [
-            "-nostdlib",
-        ],
-        "//toolchain:linux_ppc64le_freestanding_stage1_hosted": [
-            "-nostdlib",
-        ],
-        "//toolchain:linux_ppc64le_freestanding_complete": [
-            "-nostdlib",
-        ],
+    args = select(ppc64le_freestanding_select([
+        "-nostdlib",
+        "-static",
+    ]) | {
         "//toolchain:runtimes_all": [],
         "//toolchain:runtimes_stage1": [
             "-nostdlib++",

--- a/toolchain/runtimes/args/BUILD.bazel
+++ b/toolchain/runtimes/args/BUILD.bazel
@@ -205,6 +205,18 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
     args = select({
+        "//toolchain:linux_ppc64le_freestanding_stage0": [
+            "-nostdlib",
+        ],
+        "//toolchain:linux_ppc64le_freestanding_stage1": [
+            "-nostdlib",
+        ],
+        "//toolchain:linux_ppc64le_freestanding_stage1_hosted": [
+            "-nostdlib",
+        ],
+        "//toolchain:linux_ppc64le_freestanding_complete": [
+            "-nostdlib",
+        ],
         "//toolchain:runtimes_all": [],
         "//toolchain:runtimes_stage1": [
             "-nostdlib++",

--- a/toolchain/selects.bzl
+++ b/toolchain/selects.bzl
@@ -40,7 +40,11 @@ def platform_extra_binary(binary):
     })
 
 def platform_module_map(exec_os, exec_cpu):
-    return Label(_tool_repo(exec_os, exec_cpu) + ":module_map")
+    tool_repo = _tool_repo(exec_os, exec_cpu)
+    return select({
+        "@llvm//platforms/config:linux_ppc64le": Label(tool_repo + ":freestanding_module_map"),
+        "//conditions:default": Label(tool_repo + ":module_map"),
+    })
 
 def resource_dir_arg(exec_os, exec_cpu):
     return Label(_tool_repo(exec_os, exec_cpu) + ":compile_resource_dir")
@@ -53,6 +57,7 @@ def platform_cc_tool_map(exec_os, exec_cpu):
     # point at further aliases that use `select`, those will resolve according to the exec platform.
     # See https://github.com/bazelbuild/bazel/issues/27623#issuecomment-3529439585 for more details.
     return select({
+        "@llvm//toolchain:linux_ppc64le_freestanding_complete": Label(tool_repo + ":staged_default_tools"),
         "@llvm//toolchain:linux_complete": Label(tool_repo + ":tools_with_interface_libraries"),
         "@llvm//toolchain:macos_complete_with_libtool": Label(tool_repo + ":tools_with_dsym_and_libtool"),
         "@llvm//toolchain:macos_complete": Label(tool_repo + ":tools_with_dsym"),


### PR DESCRIPTION
## Summary

- add a Linux PPC64LE LLVM platform and target triple whose default behavior is freestanding
- keep source/bootstrap, hosted-wrapper, and FDO-training stages free of target libc, CRT, and compiler-runtime dependencies
- resolve the default libc from both target OS and CPU, so CPU+OS-only RISC-V selects its supported glibc/kernel-header baseline while ordinary Linux targets retain the existing default
- provide an integrity-pinned host-tools repository for repository-time `clang` and `ld.lld` probes, including native `.exe` paths on Windows and explicit host metadata
- pin the six-host LLVM 22.1.8 preview prebuilts produced from this branch

## Why

Kernel builds commonly provide only CPU and OS platform constraints. PPC64LE was not represented as a freestanding LLVM target, so selecting Linux PPC64LE could pull hosted runtime configuration into bootstrap and link actions. RISC-V also needs a newer libc/kernel-header baseline than the generic Linux default when no libc constraint is present. Repository-time compiler probes must use executables matching the repository host.

This makes the toolchain usable by generic kernel rules without requiring Linux configuration symbols to choose architecture or hosted/freestanding behavior.

## Validation

- GitHub CI: 37/37 checks passed on the final head
- built all six minimal prebuilt archives from an initially cold, isolated output base with remote execution: Linux amd64/arm64, macOS amd64/arm64, and Windows amd64/arm64
- published and verified the immutable preview release from [workflow run 30733651342](https://github.com/fionera/hermetic-llvm/actions/runs/30733651342)
- downloaded all six release archives, matched their SHA-256 digests, and verified native `clang` and `ld.lld` executables (including `.exe` on Windows)
- integration CI builds compiler-rt for an unconstrained Linux+RISC-V platform and verifies glibc 2.33/kernel headers 5.12.19; the x86 control verifies glibc 2.28/kernel headers 4.19.325
- the PPC64LE workflow builds and links freestanding objects/executables while rejecting hosted libc, CRT, C++ runtime, and compiler-runtime dependencies
- focused libc-default, host-tools, formatting, Gazelle, and cquery checks passed

The preview pins are intentionally immutable contributor-owned release URLs while this PR is a draft. Before making it ready for merge, publish/copy those assets under hermeticbuild and update the release key and URLs.